### PR TITLE
Add CORS middleware + test structure for Pliny gem

### DIFF
--- a/lib/app/main.rb
+++ b/lib/app/main.rb
@@ -1,6 +1,7 @@
 module App
   Main = Rack::Builder.new do
     use Rack::Instruments
+    use Pliny::Middleware::CORS
 
     use Sinatra::Router do
       # mount all individual Sinatra apps here

--- a/vendor/pliny/Gemfile
+++ b/vendor/pliny/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :test do
+  gem "rack-test"
+  gem "rr"
+end

--- a/vendor/pliny/Gemfile.lock
+++ b/vendor/pliny/Gemfile.lock
@@ -1,0 +1,28 @@
+PATH
+  remote: .
+  specs:
+    pliny (0.0.1)
+      sinatra
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    rr (1.1.2)
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pliny!
+  rack-test
+  rr

--- a/vendor/pliny/Rakefile
+++ b/vendor/pliny/Rakefile
@@ -1,0 +1,10 @@
+require "rake/testtask"
+
+task :default => :test
+
+Rake::TestTask.new do |task|
+  task.libs << "lib"
+  task.libs << "test"
+  task.name = :test
+  task.test_files = FileList["test/**/*_test.rb"]
+end

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -1,3 +1,5 @@
+require "sinatra"
+
 module Pliny
   def self.initialize!
     Utils.require_relative_glob("config/initializers/*.rb")
@@ -9,3 +11,5 @@ module Pliny
 end
 
 require_relative "pliny/utils"
+
+require_relative "pliny/middleware/cors"

--- a/vendor/pliny/lib/pliny/middleware/cors.rb
+++ b/vendor/pliny/lib/pliny/middleware/cors.rb
@@ -1,0 +1,43 @@
+module Pliny::Middleware
+  class CORS
+
+    AllowMethods  = %w( GET POST PUT PATCH DELETE OPTIONS )
+    AllowHeaders  = %w( * Content-Type Accept AUTHORIZATION Cache-Control )
+    ExposeHeaders = %w( Cache-Control Content-Language Content-Type Expires Last-Modified Pragma )
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # preflight request: render a stub 200 with the CORS headers
+      if cors_request?(env) && env["REQUEST_METHOD"] == "OPTIONS"
+        [200, cors_headers(env), [""]]
+      else
+        status, headers, response = @app.call(env)
+
+        # regualar CORS request: append CORS headers to response
+        if cors_request?(env)
+          headers.merge!(cors_headers(env))
+        end
+
+        [status, headers, response]
+      end
+    end
+
+    def cors_request?(env)
+      env.has_key?("HTTP_ORIGIN")
+    end
+
+    def cors_headers(env)
+      {
+        'Access-Control-Allow-Origin' => env["HTTP_ORIGIN"],
+        'Access-Control-Allow-Methods' => AllowMethods.join(', '),
+        'Access-Control-Allow-Headers' => AllowHeaders.join(', '),
+        'Access-Control-Allow-Credentials' => "true",
+        'Access-Control-Max-Age' => "1728000",
+        'Access-Control-Expose-Headers' => ExposeHeaders.join(', ')
+      }
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/middleware/cors.rb
+++ b/vendor/pliny/lib/pliny/middleware/cors.rb
@@ -1,9 +1,12 @@
 module Pliny::Middleware
   class CORS
 
-    AllowMethods  = %w( GET POST PUT PATCH DELETE OPTIONS )
-    AllowHeaders  = %w( * Content-Type Accept AUTHORIZATION Cache-Control )
-    ExposeHeaders = %w( Cache-Control Content-Language Content-Type Expires Last-Modified Pragma )
+    ALLOW_METHODS  =
+      %w( GET POST PUT PATCH DELETE OPTIONS ).freeze
+    ALLOW_HEADERS  =
+      %w( * Content-Type Accept AUTHORIZATION Cache-Control ).freeze
+    EXPOSE_HEADERS =
+      %w( Cache-Control Content-Language Content-Type Expires Last-Modified Pragma ).freeze
 
     def initialize(app)
       @app = app
@@ -31,12 +34,12 @@ module Pliny::Middleware
 
     def cors_headers(env)
       {
-        'Access-Control-Allow-Origin' => env["HTTP_ORIGIN"],
-        'Access-Control-Allow-Methods' => AllowMethods.join(', '),
-        'Access-Control-Allow-Headers' => AllowHeaders.join(', '),
+        'Access-Control-Allow-Origin'      => env["HTTP_ORIGIN"],
+        'Access-Control-Allow-Methods'     => ALLOW_METHODS.join(', '),
+        'Access-Control-Allow-Headers'     => ALLOW_HEADERS.join(', '),
         'Access-Control-Allow-Credentials' => "true",
-        'Access-Control-Max-Age' => "1728000",
-        'Access-Control-Expose-Headers' => ExposeHeaders.join(', ')
+        'Access-Control-Max-Age'           => "1728000",
+        'Access-Control-Expose-Headers'    => EXPOSE_HEADERS.join(', ')
       }
     end
   end

--- a/vendor/pliny/pliny.gemspec
+++ b/vendor/pliny/pliny.gemspec
@@ -10,4 +10,6 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
 
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} }
+
+  gem.add_dependency "sinatra"
 end

--- a/vendor/pliny/test/middleware/cors_test.rb
+++ b/vendor/pliny/test/middleware/cors_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+describe Pliny::Middleware::CORS do
+  include Rack::Test::Methods
+
+  def app
+    Rack::Builder.new do
+      use Rack::Lint
+      use Pliny::Middleware::CORS
+      run Sinatra.new {
+        get "/" do
+          "hi"
+        end
+      }
+    end
+  end
+
+  it "doesn't do anything when the Origin header is not present" do
+    get "/"
+    assert_equal 200, last_response.status
+    assert_equal "hi", last_response.body
+    assert_equal nil, last_response.headers["Access-Control-Allow-Origin"]
+  end
+
+  it "intercepts OPTION requests to render a stub (preflight request)" do
+    header "Origin", "http://localhost"
+    options "/"
+    assert_equal 200, last_response.status
+    assert_equal "", last_response.body
+    assert_equal "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      last_response.headers["Access-Control-Allow-Methods"]
+    assert_equal "http://localhost",
+      last_response.headers["Access-Control-Allow-Origin"]
+  end
+
+  it "delegates other calls, adding the CORS headers to the response" do
+    header "Origin", "http://localhost"
+    get "/"
+    assert_equal 200, last_response.status
+    assert_equal "hi", last_response.body
+    assert_equal "http://localhost",
+      last_response.headers["Access-Control-Allow-Origin"]
+  end
+end

--- a/vendor/pliny/test/test_helper.rb
+++ b/vendor/pliny/test/test_helper.rb
@@ -1,0 +1,12 @@
+# make sure this is set before Sinatra is required
+ENV["RACK_ENV"] = "test"
+
+require "rubygems"
+require "bundler"
+
+Bundler.require(:default, :test)
+
+require "minitest/autorun"
+require "rr"
+
+require_relative "../lib/pliny"


### PR DESCRIPTION
Uses a second testing hierarchy specifically for the Pliny gem itself
(the first will aimed as the test suite of the application being built).
