### PR TITLE
Pliny's RequestStore

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -2,6 +2,7 @@ module App
 end
 
 require_relative "endpoints/base"
+require_relative "request_store"
 
 Pliny::Utils.require_relative_glob("lib/endpoints/**/*.rb")
 

--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -1,0 +1,33 @@
+module RequestStore
+  def self.clear!
+    Thread.current[:request_store] = {}
+  end
+
+  # A request-specific log store that will be added to all contextual logging
+  # calls. Key data relating the request should be added here such as
+  # request ID, authenticated user, etc.
+  def self.log_context
+    store[:log_context] ||= {}
+  end
+
+  # Request ID of the current request.
+  def self.request_id
+    store[:request_id]
+  end
+
+  def self.seed(env)
+    store[:request_id] =
+      env["REQUEST_IDS"] ? env["REQUEST_IDS"].join(",") : nil
+
+    # a global context that evolves over the lifetime of the request, and is
+    # used to tag all log messages that it produces
+    log_context.merge! \
+      request_id: env["REQUEST_IDS"] ? env["REQUEST_IDS"].join(",") : nil
+  end
+
+  protected
+
+  def self.store
+    Thread.current[:request_store] ||= {}
+  end
+end

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -7,7 +7,6 @@ Routes = Rack::Builder.new do
 
   use Sinatra::Router do
     # mount all individual Sinatra apps here
-    mount Endpoints::Apps
 
     # root app; but will also handle some defaults like 404
     run Endpoints::Root

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -3,6 +3,7 @@ Routes = Rack::Builder.new do
   use Rack::Instruments
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID
+  use Pliny::Middleware::RequestStore, store: ::RequestStore
 
   use Sinatra::Router do
     # mount all individual Sinatra apps here

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -1,6 +1,8 @@
 require "sinatra"
+
 require "pliny/generator"
 require "pliny/log"
+require "pliny/request_store"
 require "pliny/utils"
 require "pliny/middleware/cors"
 require "pliny/middleware/request_id"

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -6,6 +6,7 @@ require "pliny/request_store"
 require "pliny/utils"
 require "pliny/middleware/cors"
 require "pliny/middleware/request_id"
+require "pliny/middleware/request_store"
 
 module Pliny
   extend Log

--- a/vendor/pliny/lib/pliny/middleware/request_store.rb
+++ b/vendor/pliny/lib/pliny/middleware/request_store.rb
@@ -1,0 +1,14 @@
+module Pliny::Middleware
+  class RequestStore
+    def initialize(app, options={})
+      @app = app
+      @store = options[:store] || Pliny::RequestStore
+    end
+
+    def call(env)
+      @store.clear!
+      @store.seed(env)
+      @app.call(env)
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/request_store.rb
+++ b/vendor/pliny/lib/pliny/request_store.rb
@@ -1,0 +1,35 @@
+module Pliny
+  module RequestStore
+    def self.clear!
+      Thread.current[:request_store] = {}
+    end
+
+    # A request-specific log store that will be added to all contextual logging
+    # calls. Key data relating the request should be added here such as
+    # request ID, authenticated user, etc.
+    def self.log_context
+      store[:log_context] ||= {}
+    end
+
+    # Request ID of the current request.
+    def self.request_id
+      store[:request_id]
+    end
+
+    def self.seed(env)
+      store[:request_id] =
+        env["REQUEST_IDS"] ? env["REQUEST_IDS"].join(",") : nil
+
+      # a global context that evolves over the lifetime of the request, and is
+      # used to tag all log messages that it produces
+      log_context.merge! \
+        request_id: env["REQUEST_IDS"] ? env["REQUEST_IDS"].join(",") : nil
+    end
+
+    protected
+
+    def self.store
+      Thread.current[:request_store] ||= {}
+    end
+  end
+end

--- a/vendor/pliny/test/middleware/request_store_test.rb
+++ b/vendor/pliny/test/middleware/request_store_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+describe Pliny::Middleware::RequestStore do
+  include Rack::Test::Methods
+
+  def app
+    Rack::Builder.new do
+      use Rack::Lint
+      use Pliny::Middleware::RequestStore, store: Pliny::RequestStore
+      run Sinatra.new {
+        get "/" do
+          "hi"
+        end
+      }
+    end
+  end
+
+  it "clears the store" do
+    mock(Pliny::RequestStore).clear!
+    get "/"
+  end
+
+  it "seeds the store" do
+    mock(Pliny::RequestStore).seed.with_any_args
+    get "/"
+  end
+end

--- a/vendor/pliny/test/request_store_test.rb
+++ b/vendor/pliny/test/request_store_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+describe Pliny::RequestStore do
+  before do
+    @env = {
+      "REQUEST_IDS" => ["abc", "def"]
+    }
+  end
+
+  it "seeds .request_id" do
+    Pliny::RequestStore.seed(@env)
+    assert_equal "abc,def", Pliny::RequestStore.request_id
+  end
+
+  it "seeds .log_context" do
+    Pliny::RequestStore.seed(@env)
+    assert_equal "abc,def", Pliny::RequestStore.log_context[:request_id]
+  end
+
+  it "is cleared by clear!" do
+    Pliny::RequestStore.seed(@env)
+    Pliny::RequestStore.clear!
+    assert_nil Pliny::RequestStore.request_id
+  end
+end


### PR DESCRIPTION
Provide a `RequestStore` for Pliny similar to what we have in API that
includes a Request-Id and a logging context.

The idea here is that middleware lives in the Pliny gem, but the
RequestStore itself lives in the leaf app so that it can be customized
as needed.
