### PR TITLE
Middleware: timeout + rescue errors

### DIFF
--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -3,6 +3,9 @@ Routes = Rack::Builder.new do
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID
   use Pliny::Middleware::RequestStore, store: Pliny::RequestStore
+  use Pliny::Middleware::Timeout, timeout: 45
+  use Rack::Deflater
+  use Rack::MethodOverride
 
   use Sinatra::Router do
     # mount all individual Sinatra apps here

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,4 +1,5 @@
 Routes = Rack::Builder.new do
+  use Pliny::Middleware::RescueErrors
   use Honeybadger::Rack
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID

--- a/vendor/pliny/Gemfile.lock
+++ b/vendor/pliny/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     pliny (0.0.1)
       activesupport
+      multi_json
       sinatra
 
 GEM

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -2,6 +2,7 @@ require "sinatra"
 
 module Pliny ; end
 
+require "pliny/error"
 require "pliny/extensions/instruments"
 require "pliny/generator"
 require "pliny/log"
@@ -10,6 +11,7 @@ require "pliny/utils"
 require "pliny/middleware/cors"
 require "pliny/middleware/request_id"
 require "pliny/middleware/request_store"
+require "pliny/middleware/timeout"
 
 module Pliny
   extend Log

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -1,3 +1,4 @@
+require "multi_json"
 require "sinatra"
 
 module Pliny ; end
@@ -11,6 +12,7 @@ require "pliny/utils"
 require "pliny/middleware/cors"
 require "pliny/middleware/request_id"
 require "pliny/middleware/request_store"
+require "pliny/middleware/rescue_errors"
 require "pliny/middleware/timeout"
 
 module Pliny

--- a/vendor/pliny/lib/pliny/error.rb
+++ b/vendor/pliny/lib/pliny/error.rb
@@ -1,12 +1,22 @@
 module Pliny::Error
   class Base < StandardError
+    attr_accessor :id
     attr_accessor :status
   end
 
+  class InternalServerError < Base
+    def initialize(message="Internal server error.")
+      @id = :internal_server_error
+      @status = 500
+      super(message)
+    end
+  end
+
   class ServiceUnavailable < Base
-    def initialize(message)
+    def initialize(message="Service unavailable.")
+      @id = :service_unavailable
       @status = 503
-      super
+      super(message)
     end
   end
 end

--- a/vendor/pliny/lib/pliny/error.rb
+++ b/vendor/pliny/lib/pliny/error.rb
@@ -1,0 +1,12 @@
+module Pliny::Error
+  class Base < StandardError
+    attr_accessor :status
+  end
+
+  class ServiceUnavailable < Base
+    def initialize(message)
+      @status = 503
+      super
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/middleware/rescue_errors.rb
+++ b/vendor/pliny/lib/pliny/middleware/rescue_errors.rb
@@ -1,0 +1,24 @@
+module Pliny::Middleware
+  class RescueErrors
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    rescue Pliny::Error::Base => e
+      render(e, env)
+    rescue Exception => e
+    # Pliny.log_exception(e)
+      render(Pliny::Error::InternalServerError.new, env)
+    end
+
+    private
+
+    def render(e, env)
+      headers = { "Content-Type" => "application/json; charset=utf-8" }
+      error = { id: e.id, message: e.message, status: e.status }
+      [e.status, headers, [MultiJson.encode(error)]]
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/middleware/timeout.rb
+++ b/vendor/pliny/lib/pliny/middleware/timeout.rb
@@ -1,0 +1,25 @@
+require "timeout"
+
+module Pliny::Middleware
+  # Requires that Pliny::Error::RescueErrors is nested above it.
+  class Timeout
+    def initialize(app, options={})
+      @app = app
+      @timeout = options[:timeout] || 45
+    end
+
+    def call(env)
+      ::Timeout.timeout(@timeout, RequestTimeout) do
+        @app.call(env)
+      end
+    rescue RequestTimeout
+    # Pliny::Sample.measure "requests.timeouts"
+      raise Pliny::Error::ServiceUnavailable, "Timeout reached."
+    end
+
+    # use a custom Timeout class so it can't be rescued accidentally by
+    # internal calls
+    class RequestTimeout < Exception
+    end
+  end
+end

--- a/vendor/pliny/pliny.gemspec
+++ b/vendor/pliny/pliny.gemspec
@@ -12,5 +12,6 @@ Gem::Specification.new do |gem|
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} }
 
   gem.add_dependency "activesupport"
+  gem.add_dependency "multi_json"
   gem.add_dependency "sinatra"
 end

--- a/vendor/pliny/test/middleware/rescue_errors_test.rb
+++ b/vendor/pliny/test/middleware/rescue_errors_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+describe Pliny::Middleware::RescueErrors do
+  include Rack::Test::Methods
+
+  class BadMiddleware
+    def call(env)
+      if env["PATH_INFO"] == "/api-error"
+        raise Pliny::Error::ServiceUnavailable
+      else
+        raise "Omg!"
+      end
+    end
+  end
+
+  def app
+    Rack::Builder.new do
+      use Rack::Lint
+      use Pliny::Middleware::RescueErrors
+      run BadMiddleware.new
+    end
+  end
+
+  it "intercepts Pliny errors and renders" do
+    get "/api-error"
+    assert_equal 503, last_response.status
+    error_json = MultiJson.decode(last_response.body)
+    assert_equal "service_unavailable", error_json["id"]
+    assert_equal "Service unavailable.", error_json["message"]
+    assert_equal 503, error_json["status"]
+  end
+
+  it "intercepts exceptions and renders" do
+    get "/"
+    assert_equal 500, last_response.status
+    error_json = MultiJson.decode(last_response.body)
+    assert_equal "internal_server_error", error_json["id"]
+    assert_equal "Internal server error.", error_json["message"]
+    assert_equal 500, error_json["status"]
+  end
+end

--- a/vendor/pliny/test/middleware/timeout_test.rb
+++ b/vendor/pliny/test/middleware/timeout_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+describe Pliny::Middleware::Timeout do
+  include Rack::Test::Methods
+
+  def app
+    Rack::Builder.new do
+      use Rack::Lint
+      use Pliny::Middleware::Timeout
+      run Sinatra.new {
+        get "/" do
+          200
+        end
+
+        get "/timeout" do
+          raise Pliny::Middleware::Timeout::RequestTimeout
+        end
+      }
+    end
+  end
+
+  it "passes through requests that don't timeout normally" do
+    get "/"
+    assert_equal 200, last_response.status
+  end
+
+  it "responds with an error on a timeout" do
+    assert_raises(Pliny::Error::ServiceUnavailable) do
+      get "/timeout"
+    end
+  end
+end


### PR DESCRIPTION
New middleware for timeout and for rescuing errors. Also added a few
sample Pliny errors.
