### PR TITLE
Use Sinatra::Reloader

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -1,8 +1,13 @@
+require 'sinatra/reloader'
 module Endpoints
   # The base class for all Sinatra-based endpoints. Use sparingly.
   class Base < Sinatra::Base
     register Pliny::Extensions::Instruments
     register Sinatra::Namespace
+
+    configure :development do
+      register Sinatra::Reloader
+    end
 
     not_found do
       content_type :json


### PR DESCRIPTION
Does anyone oppose including [Sinatra::Reloader](http://www.sinatrarb.com/contrib/reloader.html) for development? Simple as changing `lib/endpoints/base.rb`:

``` ruby

require 'sinatra/reloader'
module Endpoints
  # The base class for all Sinatra-based endpoints. Use sparingly.
  class Base < Sinatra::Base
    register Pliny::Extensions::Instruments
    register Sinatra::Namespace

    configure :development do
      register Sinatra::Reloader
    end

    not_found do
      content_type :json
      status 404
      "{}"
    end
  end
end
```

And future code changes are reloaded in development mode (maybe add an explicit `RACK_ENV=development` to the `.env*` files). 
