### PR TITLE
Add Fine-style configuration file for access to ENV

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -13,12 +13,15 @@ require "pliny/config_helpers"
 module Config
   extend Pliny::ConfigHelpers
 
+  # Mandatory -- exception is raised for these variables when missing.
   mandatory \
     :database_url
 
+  # Optional -- value is returned or `nil` if it wasn't present.
   optional \
     :placeholder
 
+  # Override -- value is returned or the set default. Remember to typecast.
   override \
     port:             5000,
     puma_max_threads: 16,

--- a/config/config.rb
+++ b/config/config.rb
@@ -1,0 +1,28 @@
+require "pliny/config_helpers"
+
+# Access all config keys like the following:
+#
+#     Config.database_url
+#
+# Each accessor corresponds directly to an ENV key, which has the same name
+# except upcased, i.e. `DATABASE_URL`.
+#
+# Note that *all* keys will come out as strings even if the override was a
+# different type. Make sure to typecast any values that need to be something
+# else (i.e. `.to_i`).
+module Config
+  extend Pliny::ConfigHelpers
+
+  mandatory \
+    :database_url
+
+  optional \
+    :placeholder
+
+  override \
+    port:             5000,
+    puma_max_threads: 16,
+    puma_min_threads: 1,
+    puma_workers:     3,
+    rack_env:         "development"
+end

--- a/config/initializers/db.rb
+++ b/config/initializers/db.rb
@@ -1,2 +1,1 @@
-abort("Missing DATABASE_URL") unless ENV["DATABASE_URL"]
-DB = Sequel.connect(ENV["DATABASE_URL"])
+DB = Sequel.connect(Config.database_url)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,9 +1,10 @@
-environment (ENV["RACK_ENV"] || "development")
-port ENV["PORT"] || 5000
+require "./config/config"
+
+environment Config.rack_env
+port Config.port
 quiet
-threads Integer(ENV['PUMA_MIN_THREADS']  || 1),
-  Integer(ENV['PUMA_MAX_THREADS'] || 16)
-workers Integer(ENV['PUMA_WORKERS'] || 3)
+threads Config.puma_min_threads.to_i, Config.puma_max_threads.to_i
+workers Config.puma_workers.to_i
 
 on_worker_boot do
   # force Sequel's thread pool to be refreshed

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,6 +1,8 @@
 module App
 end
 
+require_relative "../config/config"
+
 require_relative "endpoints/base"
 Pliny::Utils.require_relative_glob("lib/endpoints/**/*.rb")
 

--- a/vendor/pliny/lib/pliny/config_helpers.rb
+++ b/vendor/pliny/lib/pliny/config_helpers.rb
@@ -1,0 +1,21 @@
+module Pliny
+  module ConfigHelpers
+    def optional(*attrs)
+      attrs.each do |attr|
+        instance_eval "def #{attr}; @#{attr} ||= ENV['#{attr.upcase}'] end", __FILE__, __LINE__
+      end
+    end
+
+    def mandatory(*attrs)
+      attrs.each do |attr|
+        instance_eval "def #{attr}; @#{attr} ||= ENV['#{attr.upcase}'] || raise('missing=#{attr.upcase}') end", __FILE__, __LINE__
+      end
+    end
+
+    def override(attrs)
+      attrs.each do |attr, value|
+        instance_eval "def #{attr}; @#{attr} ||= ENV['#{attr.upcase}'] || '#{value}'.to_s end", __FILE__, __LINE__
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is probably a little more controversial, but adds a configuration
file to make access of config vars easier -- similar to what we have in
API. It's not too obvious why this is useful at this scale, but it helps
clean things up a lot once a project gets to a certain size.

Thoughts on this one?
