### PR TITLE
Model loading strategy

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,4 +7,6 @@ $stdout.sync = true
 
 Pliny.initialize!
 
+require "./lib/models"
+
 run Routes

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -1,0 +1,4 @@
+# Sequel requires a DB connection before any models can successfully be loaded
+# so we initialize them "late" in a separate load file.
+puts "loading models!!"
+Pliny::Utils.require_relative_glob("lib/models/**/*.rb")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,5 @@ end
 ENV.update(Pliny::Utils.parse_env("#{Pliny.root}/.env.test"))
 
 Pliny.initialize!
+
+require_relative "../lib/models"


### PR DESCRIPTION
Sequel models need to have an initialized database connection before
they can be required so load them to a little later than the rest of the
app for both main boot and tests.
