### PR TITLE
Suppress Ruby's "use RbConfig" instead message

### DIFF
--- a/vendor/pliny/lib/pliny/config_helpers.rb
+++ b/vendor/pliny/lib/pliny/config_helpers.rb
@@ -19,3 +19,6 @@ module Pliny
     end
   end
 end
+
+# Supress the "use RbConfig instead" warning.
+Object.send :remove_const, :Config


### PR DESCRIPTION
Also make sure that we don't conflate our `Config` with the one Ruby ships
with.
