### PR TITLE
Improve default model migration

### DIFF
--- a/vendor/pliny/lib/pliny/templates/model.erb
+++ b/vendor/pliny/lib/pliny/templates/model.erb
@@ -1,3 +1,5 @@
 class <%= class_name %> < Sequel::Model
 
+  plugin :timestamps
+
 end

--- a/vendor/pliny/lib/pliny/templates/model_migration.erb
+++ b/vendor/pliny/lib/pliny/templates/model_migration.erb
@@ -1,8 +1,8 @@
 Sequel.migration do
   change do
     create_table(:<%= table_name %>) do
-      uuid         :uuid, primary_key: true, default: Sequel.function(:uuid_generate_v4)
-      timestamptz  :created_at, default: Sequel.function(:now)
+      uuid         :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
+      timestamptz  :created_at, default: Sequel.function(:now), null: false
       timestamptz  :updated_at
       timestamptz  :deleted_at
     end

--- a/vendor/pliny/lib/pliny/templates/model_migration.erb
+++ b/vendor/pliny/lib/pliny/templates/model_migration.erb
@@ -1,9 +1,10 @@
 Sequel.migration do
   change do
     create_table(:<%= table_name %>) do
-      primary_key :id
-      timestamp   :created_at
-      timestamp   :updated_at
+      uuid         :uuid, primary_key: true, default: Sequel.function(:uuid_generate_v4)
+      timestamptz  :created_at
+      timestamptz  :updated_at
+      timestamptz  :deleted_at
     end
   end
 end

--- a/vendor/pliny/lib/pliny/templates/model_migration.erb
+++ b/vendor/pliny/lib/pliny/templates/model_migration.erb
@@ -2,7 +2,7 @@ Sequel.migration do
   change do
     create_table(:<%= table_name %>) do
       uuid         :uuid, primary_key: true, default: Sequel.function(:uuid_generate_v4)
-      timestamptz  :created_at
+      timestamptz  :created_at, default: Sequel.function(:now)
       timestamptz  :updated_at
       timestamptz  :deleted_at
     end


### PR DESCRIPTION
Use uuids as primary keys. Timestamptz for timestamps. And always included deleted_at, whether or not it gets used. One caveat here is that uuid extension on db might need to get loaded first - I put that in migrations, but it might be something safe to assume is set here.
