### PR TITLE
Start moving executables to pliny-*

### DIFF
--- a/vendor/pliny/bin/pliny-generate
+++ b/vendor/pliny/bin/pliny-generate
@@ -3,4 +3,4 @@
 require "bundler"
 Bundler.require
 
-Pliny::Generator.run(ARGV.dup)
+Pliny::Commands::Generator.run(ARGV.dup)

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -3,9 +3,9 @@ require "sinatra"
 
 module Pliny ; end
 
+require "pliny/commands/generator"
 require "pliny/error"
 require "pliny/extensions/instruments"
-require "pliny/generator"
 require "pliny/log"
 require "pliny/request_store"
 require "pliny/utils"

--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -3,7 +3,7 @@ require "fileutils"
 require "ostruct"
 require "active_support/inflector"
 
-module Pliny
+module Pliny::Commands
   class Generator
     attr_accessor :args, :stream
 
@@ -115,7 +115,7 @@ module Pliny
     end
 
     def render_template(template_file, destination_path, vars={})
-      template_path = File.dirname(__FILE__) + "/templates/#{template_file}"
+      template_path = File.dirname(__FILE__) + "/../templates/#{template_file}"
       template = ERB.new(File.read(template_path))
       FileUtils.mkdir_p(File.dirname(destination_path))
       File.open(destination_path, "w") do |f|

--- a/vendor/pliny/pliny.gemspec
+++ b/vendor/pliny/pliny.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.description = "Pliny is a set of base classes and helpers to help developers write excellent APIs in Sinatra"
   gem.license     = "MIT"
 
+  gem.executables = %(pliny-generate)
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} }
 
   gem.add_dependency "activesupport"

--- a/vendor/pliny/test/commands/generator_test.rb
+++ b/vendor/pliny/test/commands/generator_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-describe Pliny::Generator do
+describe Pliny::Commands::Generator do
   before do
-    @gen = Pliny::Generator.new({}, StringIO.new)
+    @gen = Pliny::Commands::Generator.new({}, StringIO.new)
   end
 
   describe "#class_name" do


### PR DESCRIPTION
Start moving executables that are very much specific to the framework
(i.e. it won't make sense for them to be overridden directly in the
project) out of `bin/` into the gem itself as a provide `pliny-*`
executable.

I think we'll probably want to do a similar think for everything that we
currently have in `lib/tasks`. If those operations stay inside the
template itself, it'll be more difficult for us to make changes to them
down the road. This might result in a list of executables like the
following:

```
pliny-db-create
pliny-db-drop
pliny-db-migrate
pliny-db-reset
pliny-db-rollback
pliny-db-schema-dump
pliny-db-schema-load
```

This also gets us easy tab completion for free, and allows us to start
easily adding a variety of other administrative-type tools. Thoughts?
