### PR TITLE
Extracted `pliny-migrate` + multi-env support

### DIFF
--- a/vendor/pliny/Gemfile.lock
+++ b/vendor/pliny/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     pliny (0.0.1)
       activesupport
       multi_json
+      pg
       sequel
       sinatra
 
@@ -20,6 +21,7 @@ GEM
     i18n (0.6.9)
     minitest (4.7.5)
     multi_json (1.9.2)
+    pg (0.17.1)
     rack (1.5.2)
     rack-protection (1.5.2)
       rack

--- a/vendor/pliny/Gemfile.lock
+++ b/vendor/pliny/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     pliny (0.0.1)
       activesupport
       multi_json
+      sequel
       sinatra
 
 GEM
@@ -25,6 +26,7 @@ GEM
     rack-test (0.6.2)
       rack (>= 1.0)
     rr (1.1.2)
+    sequel (4.8.0)
     sinatra (1.4.4)
       rack (~> 1.4)
       rack-protection (~> 1.4)

--- a/vendor/pliny/bin/pliny-migrate
+++ b/vendor/pliny/bin/pliny-migrate
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "bundler"
+Bundler.require
+
+Pliny::Commands::Migrator.run(ARGV.dup)

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -4,6 +4,7 @@ require "sinatra"
 module Pliny ; end
 
 require "pliny/commands/generator"
+require "pliny/commands/migrator"
 require "pliny/error"
 require "pliny/extensions/instruments"
 require "pliny/log"

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -3,6 +3,7 @@ require "sinatra"
 
 module Pliny ; end
 
+require "pliny/commands/common"
 require "pliny/commands/generator"
 require "pliny/commands/migrator"
 require "pliny/error"

--- a/vendor/pliny/lib/pliny/commands/common.rb
+++ b/vendor/pliny/lib/pliny/commands/common.rb
@@ -1,5 +1,3 @@
-
-
 module Pliny::Commands
   module Common
     def chroot!

--- a/vendor/pliny/lib/pliny/commands/common.rb
+++ b/vendor/pliny/lib/pliny/commands/common.rb
@@ -1,0 +1,44 @@
+
+
+module Pliny::Commands
+  module Common
+    def chroot!
+      loop do
+        if File.exists?(File.expand_path(".env", Dir.pwd))
+          break
+        else
+          Dir.chdir("..")
+        end
+        if Pathname.new(Dir.pwd).root?
+          panic "No project found"
+        end
+      end
+      display "Root is #{root}"
+    end
+
+    def display(msg)
+      stream.puts msg
+    end
+
+    def envs
+      %w(.env .env.test).map { |env_file|
+        env_path = File.expand_path(env_file, Dir.pwd)
+        if File.exists?(env_path)
+          [env_file, Pliny::Utils.parse_env(env_path)]
+        else
+          nil
+        end
+      }.compact
+    end
+
+    def panic(msg)
+      $stderr.puts msg
+      exit 1
+    end
+
+    # Only returns root after #chroot has been called.
+    def root
+      Dir.pwd
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/commands/common.rb
+++ b/vendor/pliny/lib/pliny/commands/common.rb
@@ -4,6 +4,8 @@ module Pliny::Commands
       loop do
         if File.exists?(File.expand_path(".env", Dir.pwd))
           break
+        elsif File.exists?(File.expand_path(".env.test", Dir.pwd))
+          break
         else
           Dir.chdir("..")
         end
@@ -20,7 +22,7 @@ module Pliny::Commands
 
     def envs
       %w(.env .env.test).map { |env_file|
-        env_path = File.expand_path(env_file, Dir.pwd)
+        env_path = File.expand_path(env_file, root)
         if File.exists?(env_path)
           [env_file, Pliny::Utils.parse_env(env_path)]
         else

--- a/vendor/pliny/lib/pliny/commands/migrator.rb
+++ b/vendor/pliny/lib/pliny/commands/migrator.rb
@@ -1,0 +1,75 @@
+require "sequel"
+require "sequel/extensions/migration"
+
+module Pliny::Commands
+  class Migrator
+    def self.run(args, stream=$stdout)
+      new(args).run!
+    end
+
+    def initialize(args={}, stream=$stdout)
+      @args = args
+      @stream = stream
+    end
+
+    def run!
+      root = find_root
+      display "Root is #{root}"
+      if no_migrations?
+        display "No pending migrations"
+      else
+        envs.each do |env_file, env|
+          display "Migrating #{env_file}"
+          db = Sequel.connect(env["DATABASE_URL"])
+          Sequel::Migrator.apply(db, migrations_path)
+        end
+      end
+    end
+
+    private
+
+    attr_accessor :args, :stream
+
+    def display(msg)
+      stream.puts msg
+    end
+
+    def panic(msg)
+      $stderr.puts msg
+      exit 1
+    end
+
+    def envs
+      %w(.env .env.test).map { |env_file|
+        env_path = File.expand_path(env_file, Dir.pwd)
+        if File.exists?(env_path)
+          [env_file, Pliny::Utils.parse_env(env_path)]
+        else
+          nil
+        end
+      }.compact
+    end
+
+    def find_root
+      loop do
+      p Dir.pwd
+        if File.exists?(File.expand_path(".env", Dir.pwd))
+          return Dir.pwd
+        else
+          Dir.chdir("..")
+        end
+        if Pathname.new(Dir.pwd).root?
+          panic "No project found"
+        end
+      end
+    end
+
+    def migrations_path
+      File.expand_path("db/migrate", Dir.pwd)
+    end
+
+    def no_migrations?
+      Dir["#{migrations_path}/*.rb"].empty?
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/commands/migrator.rb
+++ b/vendor/pliny/lib/pliny/commands/migrator.rb
@@ -3,6 +3,8 @@ require "sequel/extensions/migration"
 
 module Pliny::Commands
   class Migrator
+    include Common
+
     def self.run(args, stream=$stdout)
       new(args).run!
     end
@@ -13,8 +15,7 @@ module Pliny::Commands
     end
 
     def run!
-      root = find_root
-      display "Root is #{root}"
+      chroot!
       if no_migrations?
         display "No pending migrations"
       else
@@ -29,40 +30,6 @@ module Pliny::Commands
     private
 
     attr_accessor :args, :stream
-
-    def display(msg)
-      stream.puts msg
-    end
-
-    def panic(msg)
-      $stderr.puts msg
-      exit 1
-    end
-
-    def envs
-      %w(.env .env.test).map { |env_file|
-        env_path = File.expand_path(env_file, Dir.pwd)
-        if File.exists?(env_path)
-          [env_file, Pliny::Utils.parse_env(env_path)]
-        else
-          nil
-        end
-      }.compact
-    end
-
-    def find_root
-      loop do
-      p Dir.pwd
-        if File.exists?(File.expand_path(".env", Dir.pwd))
-          return Dir.pwd
-        else
-          Dir.chdir("..")
-        end
-        if Pathname.new(Dir.pwd).root?
-          panic "No project found"
-        end
-      end
-    end
 
     def migrations_path
       File.expand_path("db/migrate", Dir.pwd)

--- a/vendor/pliny/pliny.gemspec
+++ b/vendor/pliny/pliny.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activesupport"
   gem.add_dependency "multi_json"
+  gem.add_dependency "sequel"
   gem.add_dependency "sinatra"
 end

--- a/vendor/pliny/pliny.gemspec
+++ b/vendor/pliny/pliny.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activesupport"
   gem.add_dependency "multi_json"
+  gem.add_dependency "pg"
   gem.add_dependency "sequel"
   gem.add_dependency "sinatra"
 end

--- a/vendor/pliny/pliny.gemspec
+++ b/vendor/pliny/pliny.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.description = "Pliny is a set of base classes and helpers to help developers write excellent APIs in Sinatra"
   gem.license     = "MIT"
 
-  gem.executables = %(pliny-generate)
+  gem.executables = %x{ git ls-files }.split("\n").select { |d| d =~ /^bin\// }.map { |d| d.gsub(/^bin\//, "") }
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} }
 
   gem.add_dependency "activesupport"


### PR DESCRIPTION
Add in a `pliny-migrate` command that has similar behavior to `bundle
exec rake db:migrate` today, but which will live under the Pliny gem so
that we can update it independently.

Also brings in multi-environment behavior so that the values for
`DATABASE_URL` in both `.env` and `.env.test` are respected.

```
$ pliny-migrate
Root is /Users/brandur/Documents/heroku/pliny
Migrating .env
Migrating .env.test
```
