### PR TITLE
Move root + initialization up to `App`

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,7 +5,7 @@ require "./lib/app"
 
 $stdout.sync = true
 
-Pliny.initialize!
+App.initialize!
 
 require "./lib/models"
 

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,14 +1,21 @@
 module App
+  def self.initialize!
+    Pliny::Utils.require_relative_glob("#{App.root}/config/initializers/*.rb")
+  end
+
+  def self.root
+    @@root ||= File.expand_path("../../", __FILE__)
+  end
 end
 
 require_relative "../config/config"
 
 require_relative "endpoints/base"
-Pliny::Utils.require_relative_glob("lib/endpoints/**/*.rb")
+Pliny::Utils.require_relative_glob("#{App.root}/lib/endpoints/**/*.rb")
 
 if File.exists?("./lib/mediators/base.rb")
   require_relative "mediators/base"
-  Pliny::Utils.require_relative_glob("lib/mediators/**/*.rb")
+  Pliny::Utils.require_relative_glob("#{App.root}/lib/mediators/**/*.rb")
 end
 
 require_relative "routes"

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -1,3 +1,3 @@
 # Sequel requires a DB connection before any models can successfully be loaded
 # so we initialize them "late" in a separate load file.
-Pliny::Utils.require_relative_glob("lib/models/**/*.rb")
+Pliny::Utils.require_relative_glob("#{App.root}/lib/models/**/*.rb")

--- a/vendor/pliny/lib/pliny.rb
+++ b/vendor/pliny/lib/pliny.rb
@@ -17,12 +17,4 @@ require "pliny/middleware/timeout"
 
 module Pliny
   extend Log
-
-  def self.initialize!
-    Utils.require_relative_glob("config/initializers/*.rb")
-  end
-
-  def self.root
-    @@root ||= File.expand_path("../../../../", __FILE__)
-  end
 end

--- a/vendor/pliny/lib/pliny/utils.rb
+++ b/vendor/pliny/lib/pliny/utils.rb
@@ -14,8 +14,8 @@ module Pliny
 
     # Requires an entire directory of source files in a stable way so that file
     # hierarchy is respected for load order.
-    def self.require_relative_glob(relative_path)
-      files = Dir["#{Pliny.root}/#{relative_path}"].sort_by do |file|
+    def self.require_relative_glob(path)
+      files = Dir[path].sort_by do |file|
         [file.count("/"), file]
       end
 


### PR DESCRIPTION
Currently the root detection and intialization code lives in Pliny and uses a
relative path trick to determine where the app's root is. As Pliny will have
to soon be extrated into gem form, this method will stop working.

This pull moves root detection up to the `App` itself, and also pulls 
initialization there as well. This has a nice side effect of making the 
initialization code more transparent and more customizable.
