### PR TITLE
Don't swallow all errors while in development

### DIFF
--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,5 +1,5 @@
 Routes = Rack::Builder.new do
-  use Pliny::Middleware::RescueErrors
+  use Pliny::Middleware::RescueErrors unless Config.rack_env == "development"
   use Honeybadger::Rack
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID


### PR DESCRIPTION
@neilmiddleton noted that it's somewhat difficult to get visibility into
middleware exceptions while building an app against Pliny. Standard app
exceptions should still be rendered by Sinatra as expected.

This prevents errors from being fully rescued while in development,
allowing them to bubble up and be displayed by Puma instead. This
probably isn't the greatest long term solution, but we should offer a
good handling + logging mechanism before fully turning this on.
