### PR TITLE
Simplify requires in app.rb

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -3,18 +3,21 @@ module App
     Pliny::Utils.require_glob("#{App.root}/config/initializers/*.rb")
   end
 
+  def self.require!(globs)
+    globs.map { |f| App.root + "/" + f + ".rb" }.
+      each { |f| Pliny::Utils.require_glob(f) }
+  end
+
   def self.root
     @@root ||= File.expand_path("../../", __FILE__)
   end
 end
 
-[
+App.require!([
   "config/config",
   "lib/endpoints/base",
   "lib/endpoints/**/*",
   "lib/mediators/base",
   "lib/mediators/**/*",
   "lib/routes",
-].
-map { |f| App.root + "/" + f + ".rb" }.
-each { |f| Pliny::Utils.require_glob(f) }
+])

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -8,12 +8,13 @@ module App
   end
 end
 
-require_relative "../config/config"
-
-require_relative "endpoints/base"
-Pliny::Utils.require_glob("#{App.root}/lib/endpoints/**/*.rb")
-
-require_relative "mediators/base"
-Pliny::Utils.require_glob("#{App.root}/lib/mediators/**/*.rb")
-
-require_relative "routes"
+[
+  "config/config",
+  "lib/endpoints/base",
+  "lib/endpoints/**/*",
+  "lib/mediators/base",
+  "lib/mediators/**/*",
+  "lib/routes",
+].
+map { |f| App.root + "/" + f + ".rb" }.
+each { |f| Pliny::Utils.require_glob(f) }


### PR DESCRIPTION
Simplify requires in `app.rb`. Hopefully this will also make upstream merges a little more robust as currently any changes in this file tend to cause conflicts on everything.

Depends on #43.
