### PR TITLE
Generate acceptance tests

### DIFF
--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -78,6 +78,13 @@ module Pliny::Commands
         url_path:   url_path,
       })
       display "created test #{test}"
+
+      test = "./test/acceptance/#{name}_test.rb"
+      render_template("endpoint_acceptance_test.erb", test, {
+        class_name: class_name,
+        url_path:   url_path,
+      })
+      display "created test #{test}"
     end
 
     def create_mediator

--- a/vendor/pliny/lib/pliny/templates/endpoint.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint.erb
@@ -2,15 +2,23 @@ module Endpoints
   class <%= class_name %> < Base
     namespace "<%= url_path %>" do
       get do
+        content_type :json
+        "[]"
       end
 
       delete "/:id" do |id|
+        content_type :json
+        "{}"
       end
 
       patch "/:id" do |id|
+        content_type :json
+        "{}"
       end
 
       post do
+        content_type :json
+        "{}"
       end
     end
   end

--- a/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+describe Endpoints::<%= class_name %> do
+  def app
+    Routes
+  end
+
+  it "GET <%= url_path %>" do
+    get "<%= url_path %>"
+    assert_equal 200, last_response.status
+    assert_equal [], MultiJson.decode(last_response.body)
+  end
+end


### PR DESCRIPTION
Adds API's concept of acceptance/integration tests to Pliny. The main goal of these versus the unit tests on endpoints is as follows:
1. Exercise entire HTTP stack including middleware (i.e. operates on `Routes` instead of endpoint).
2. Test for response regressions. Eventually this piece will be JSON-schema backed.
3. Avoid mocking/stubbing so that interactions between all objects in the stack can be executed without interference.

Fixes #41.
