### PR TITLE
Test initializers + quiet tests

### DIFF
--- a/test/support/log.rb
+++ b/test/support/log.rb
@@ -1,0 +1,6 @@
+unless ENV["TEST_LOGS"] == "true"
+  module Pliny::Log
+    def log(data, &block)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,3 +18,6 @@ ENV.update(Pliny::Utils.parse_env("#{App.root}/.env.test"))
 App.initialize!
 
 require_relative "../lib/models"
+
+# pull in test initializers
+Pliny::Utils.require_glob("#{App.root}/test/support/**/*.rb")


### PR DESCRIPTION
Add test initializers framework in `test/support` and a first initializer that supresses logging by default in tests unless `TEST_LOGS=true` is specified.
