### PR TITLE
JSON Schema-compliant scaffolding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 ruby "2.1.0"
 
+gem "committee"
+gem "database_cleaner"
 gem "honeybadger"
 gem "multi_json"
 gem "oj"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 ruby "2.1.0"
 
-gem "committee"
-gem "database_cleaner"
 gem "honeybadger"
 gem "multi_json"
 gem "oj"
@@ -16,6 +14,8 @@ gem "sinatra-contrib", require: ["sinatra/namespace", "sinatra/reloader"]
 gem "sinatra-router"
 
 group :test do
+  gem "committee"
+  gem "database_cleaner"
   gem "rack-test"
   gem "rr", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,10 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     backports (2.6.5)
+    committee (0.4.4)
+      multi_json (> 0.0)
+      rack (> 0.0)
+    database_cleaner (1.2.0)
     erubis (2.7.0)
     honeybadger (1.11.2)
       json
@@ -67,6 +71,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  committee
+  database_cleaner
   honeybadger
   multi_json
   oj

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -10,6 +10,7 @@ Routes = Rack::Builder.new do
 
   use Pliny::Router do
     # mount all endpoints here
+    mount Endpoints::Artists
   end
 
   # root app; but will also handle some defaults like 404

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,8 +9,16 @@ require "rr"
 
 require_relative "../lib/app"
 
+DatabaseCleaner.strategy = :transaction
+
 class MiniTest::Spec
-  include Rack::Test::Methods
+  before :each do
+    DatabaseCleaner.start
+  end
+
+  after :each do
+    DatabaseCleaner.clean
+  end
 end
 
 ENV.update(Pliny::Utils.parse_env("#{App.root}/.env.test"))

--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -29,7 +29,7 @@ module Pliny::Commands
       when "endpoint"
         create_endpoint(scaffold: false)
         create_endpoint_test
-        create_endpoint_acceptance_test
+        create_endpoint_acceptance_test(scaffold: false)
       when "mediator"
         create_mediator
         create_mediator_test
@@ -42,7 +42,7 @@ module Pliny::Commands
       when "scaffold"
         create_endpoint(scaffold: true)
         create_endpoint_test
-        create_endpoint_acceptance_test
+        create_endpoint_acceptance_test(scaffold: true)
         create_model
         create_model_migration
         create_model_test
@@ -108,9 +108,11 @@ module Pliny::Commands
       display "created test #{test}"
     end
 
-    def create_endpoint_acceptance_test
+    def create_endpoint_acceptance_test(options = {})
       test = "./test/acceptance/#{name.pluralize}_test.rb"
-      render_template("endpoint_acceptance_test.erb", test, {
+      template = options[:scaffold] ? "endpoint_scaffold_acceptance_test.erb" :
+        "endpoint_acceptance_test.erb"
+      render_template(template, test, {
         plural_class_name: plural_class_name,
         field_name: field_name,
         singular_class_name: singular_class_name,

--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -121,13 +121,13 @@ module Pliny::Commands
 
     def create_mediator
       mediator = "./lib/mediators/#{name}.rb"
-      render_template("mediator.erb", mediator, class_name: class_name)
+      render_template("mediator.erb", mediator, endpoint_class_name: endpoint_class_name)
       display "created mediator file #{mediator}"
     end
 
     def create_mediator_test
       test = "./test/mediators/#{name}_test.rb"
-      render_template("mediator_test.erb", test, class_name: class_name)
+      render_template("mediator_test.erb", test, endpoint_class_name: endpoint_class_name)
       display "created test #{test}"
     end
 

--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -64,11 +64,11 @@ module Pliny::Commands
       args[1]
     end
 
-    def model_class_name
+    def singular_class_name
       name.singularize.camelize
     end
 
-    def endpoint_class_name
+    def plural_class_name
       name.pluralize.camelize
     end
 
@@ -88,21 +88,21 @@ module Pliny::Commands
       endpoint = "./lib/endpoints/#{name.pluralize}.rb"
       template = options[:scaffold] ? "endpoint_scaffold.erb" : "endpoint.erb"
       render_template(template, endpoint, {
-        endpoint_class_name: endpoint_class_name,
-        model_class_name: model_class_name,
+        plural_class_name: plural_class_name,
+        singular_class_name: singular_class_name,
         field_name: field_name,
         url_path:   url_path,
       })
       display "created endpoint file #{endpoint}"
       display "add the following to lib/routes.rb:"
-      display "  use Endpoints::#{endpoint_class_name}"
+      display "  use Endpoints::#{plural_class_name}"
     end
 
     def create_endpoint_test
       test = "./test/endpoints/#{name.pluralize}_test.rb"
       render_template("endpoint_test.erb", test, {
-        endpoint_class_name: endpoint_class_name,
-        model_class_name: model_class_name,
+        plural_class_name: plural_class_name,
+        singular_class_name: singular_class_name,
         url_path:   url_path,
       })
       display "created test #{test}"
@@ -111,9 +111,9 @@ module Pliny::Commands
     def create_endpoint_acceptance_test
       test = "./test/acceptance/#{name.pluralize}_test.rb"
       render_template("endpoint_acceptance_test.erb", test, {
-        endpoint_class_name: endpoint_class_name,
+        plural_class_name: plural_class_name,
         field_name: field_name,
-        model_class_name: model_class_name,
+        singular_class_name: singular_class_name,
         url_path:   url_path,
       })
       display "created test #{test}"
@@ -121,13 +121,13 @@ module Pliny::Commands
 
     def create_mediator
       mediator = "./lib/mediators/#{name}.rb"
-      render_template("mediator.erb", mediator, endpoint_class_name: endpoint_class_name)
+      render_template("mediator.erb", mediator, plural_class_name: plural_class_name)
       display "created mediator file #{mediator}"
     end
 
     def create_mediator_test
       test = "./test/mediators/#{name}_test.rb"
-      render_template("mediator_test.erb", test, endpoint_class_name: endpoint_class_name)
+      render_template("mediator_test.erb", test, plural_class_name: plural_class_name)
       display "created test #{test}"
     end
 
@@ -139,7 +139,7 @@ module Pliny::Commands
 
     def create_model
       model = "./lib/models/#{name}.rb"
-      render_template("model.erb", model, model_class_name: model_class_name)
+      render_template("model.erb", model, singular_class_name: singular_class_name)
       display "created model file #{model}"
     end
 
@@ -152,7 +152,7 @@ module Pliny::Commands
 
     def create_model_test
       test = "./test/models/#{name}_test.rb"
-      render_template("model_test.erb", test, model_class_name: model_class_name)
+      render_template("model_test.erb", test, singular_class_name: singular_class_name)
       display "created test #{test}"
     end
 

--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -28,12 +28,25 @@ module Pliny::Commands
       case type
       when "endpoint"
         create_endpoint
+        create_endpoint_test
+        create_endpoint_acceptance_test
       when "mediator"
         create_mediator
+        create_mediator_test
       when "migration"
         create_migration
       when "model"
         create_model
+        create_model_migration
+        create_model_test
+      when "scaffold"
+        create_endpoint
+        create_endpoint_test
+        create_endpoint_acceptance_test
+        create_model
+        create_model_migration
+        create_model_test
+        create_schema
       when "schema"
         create_schema
       else
@@ -62,8 +75,6 @@ module Pliny::Commands
     end
 
     def create_endpoint
-      url_path   = "/" + name.gsub(/_/, '-')
-
       endpoint = "./lib/endpoints/#{name.singularize}.rb"
       render_template("endpoint.erb", endpoint, {
         class_name: class_name,
@@ -72,14 +83,18 @@ module Pliny::Commands
       display "created endpoint file #{endpoint}"
       display "add the following to lib/routes.rb:"
       display "  use Endpoints::#{class_name}"
+    end
 
+    def create_endpoint_test
       test = "./test/endpoints/#{name}_test.rb"
       render_template("endpoint_test.erb", test, {
         class_name: class_name,
         url_path:   url_path,
       })
       display "created test #{test}"
+    end
 
+    def create_endpoint_acceptance_test
       test = "./test/acceptance/#{name.singularize}_test.rb"
       render_template("endpoint_acceptance_test.erb", test, {
         class_name: class_name,
@@ -92,7 +107,9 @@ module Pliny::Commands
       mediator = "./lib/mediators/#{name}.rb"
       render_template("mediator.erb", mediator, class_name: class_name)
       display "created mediator file #{mediator}"
+    end
 
+    def create_mediator_test
       test = "./test/mediators/#{name}_test.rb"
       render_template("mediator_test.erb", test, class_name: class_name)
       display "created test #{test}"
@@ -108,12 +125,16 @@ module Pliny::Commands
       model = "./lib/models/#{name}.rb"
       render_template("model.erb", model, class_name: class_name)
       display "created model file #{model}"
+    end
 
+    def create_model_migration
       migration = "./db/migrate/#{Time.now.to_i}_create_#{table_name}.rb"
       render_template("model_migration.erb", migration,
         table_name: table_name)
       display "created migration #{migration}"
+    end
 
+    def create_model_test
       test = "./test/models/#{name}_test.rb"
       render_template("model_test.erb", test, class_name: class_name)
       display "created test #{test}"
@@ -134,6 +155,10 @@ module Pliny::Commands
       write_file(destination_path) do
         template.result(context.instance_eval { binding })
       end
+    end
+
+    def url_path
+      "/" + name.pluralize.gsub(/_/, '-')
     end
 
     def write_file(destination_path)

--- a/vendor/pliny/lib/pliny/templates/endpoint.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint.erb
@@ -10,14 +10,19 @@ module Endpoints
       end
 
       post do
+        status 201
         "{}"
       end
 
-      delete "/:id" do |id|
+      get "/:id" do
         "{}"
       end
 
       patch "/:id" do |id|
+        "{}"
+      end
+
+      delete "/:id" do |id|
         "{}"
       end
     end

--- a/vendor/pliny/lib/pliny/templates/endpoint.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint.erb
@@ -1,23 +1,23 @@
 module Endpoints
-  class <%= class_name %> < Base
+  class <%= endpoint_class_name %> < Base
     namespace "<%= url_path %>" do
-      get do
+      before do
         content_type :json
+      end
+
+      get do
         "[]"
       end
 
+      post do
+        "{}"
+      end
+
       delete "/:id" do |id|
-        content_type :json
         "{}"
       end
 
       patch "/:id" do |id|
-        content_type :json
-        "{}"
-      end
-
-      post do
-        content_type :json
         "{}"
       end
     end

--- a/vendor/pliny/lib/pliny/templates/endpoint.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint.erb
@@ -1,5 +1,5 @@
 module Endpoints
-  class <%= endpoint_class_name %> < Base
+  class <%= plural_class_name %> < Base
     namespace "<%= url_path %>" do
       before do
         content_type :json

--- a/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-describe Endpoints::<%= endpoint_class_name %> do
+describe Endpoints::<%= plural_class_name %> do
   include Committee::Test::Methods
   include Rack::Test::Methods
 
@@ -13,7 +13,7 @@ describe Endpoints::<%= endpoint_class_name %> do
   end
 
   before do
-    @<%= field_name %> = <%= model_class_name %>.create
+    @<%= field_name %> = <%= singular_class_name %>.create
 
     # temporarily touch #updated_at until we can fix prmd
     @<%= field_name %>.updated_at

--- a/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -1,13 +1,34 @@
 require "test_helper"
 
-describe Endpoints::<%= class_name %> do
+describe Endpoints::<%= endpoint_class_name %> do
+  include Committee::Test::Methods
+  include Rack::Test::Methods
+
   def app
     Routes
+  end
+
+  def schema_path
+    App.root + "/docs/schema.json"
+  end
+
+  before do
+    @<%= field_name %> = <%= model_class_name %>.create
+
+    # temporarily touch #updated_at until we can fix prmd
+    @<%= field_name %>.updated_at
+    @<%= field_name %>.save
   end
 
   it "GET <%= url_path %>" do
     get "<%= url_path %>"
     assert_equal 200, last_response.status
-    assert_equal [], MultiJson.decode(last_response.body)
+    assert_schema_conform
+  end
+
+  it "GET <%= url_path %>/:id" do
+    get "<%= url_path %>/#{@<%= field_name %>.uuid}"
+    assert_equal 200, last_response.status
+    assert_schema_conform
   end
 end

--- a/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -8,27 +8,33 @@ describe Endpoints::<%= plural_class_name %> do
     Routes
   end
 
-  def schema_path
-    App.root + "/docs/schema.json"
-  end
-
-  before do
-    @<%= field_name %> = <%= singular_class_name %>.create
-
-    # temporarily touch #updated_at until we can fix prmd
-    @<%= field_name %>.updated_at
-    @<%= field_name %>.save
-  end
-
   it "GET <%= url_path %>" do
     get "<%= url_path %>"
     assert_equal 200, last_response.status
-    assert_schema_conform
+    assert_equal "[]", last_response.body
+  end
+
+  it "POST <%= url_path %>/:id" do
+    post "<%= url_path %>"
+    assert_equal 201, last_response.status
+    assert_equal "{}", last_response.body
   end
 
   it "GET <%= url_path %>/:id" do
-    get "<%= url_path %>/#{@<%= field_name %>.uuid}"
+    get "<%= url_path %>/123"
     assert_equal 200, last_response.status
-    assert_schema_conform
+    assert_equal "{}", last_response.body
+  end
+
+  it "PATCH <%= url_path %>/:id" do
+    patch "<%= url_path %>/123"
+    assert_equal 200, last_response.status
+    assert_equal "{}", last_response.body
+  end
+
+  it "DELETE <%= url_path %>/:id" do
+    delete "<%= url_path %>/123"
+    assert_equal 200, last_response.status
+    assert_equal "{}", last_response.body
   end
 end

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
@@ -25,7 +25,7 @@ module Endpoints
       patch "/:id" do |id|
         <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
         # warning: not safe
-        <%= field_name %>.update(params)
+        #<%= field_name %>.update(params)
         MultiJson.encode serialize(<%= field_name %>)
       end
 

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
@@ -1,35 +1,35 @@
 module Endpoints
-  class <%= endpoint_class_name %> < Base
+  class <%= plural_class_name %> < Base
     namespace "<%= url_path %>" do
       before do
         content_type :json
       end
 
       get do
-        MultiJson.encode <%= model_class_name %>.all.map { |x| serialize(x) }
+        MultiJson.encode <%= singular_class_name %>.all.map { |x| serialize(x) }
       end
 
       post do
         # warning: not safe
-        <%= field_name %> = <%= model_class_name %>.new(params)
+        <%= field_name %> = <%= singular_class_name %>.new(params)
         <%= field_name %>.save
         status 201
         MultiJson.encode serialize(<%= field_name %>)
       end
 
       get "/:id" do |id|
-        <%= field_name %> = <%= model_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
         MultiJson.encode serialize(<%= field_name %>)
       end
 
       delete "/:id" do |id|
-        <%= field_name %> = <%= model_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
         <%= field_name %>.destroy
         MultiJson.encode serialize(<%= field_name %>)
       end
 
       patch "/:id" do |id|
-        <%= field_name %> = <%= model_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
         # warning: not safe
         <%= field_name %>.update(params)
         MultiJson.encode serialize(<%= field_name %>)

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
@@ -22,16 +22,16 @@ module Endpoints
         MultiJson.encode serialize(<%= field_name %>)
       end
 
-      delete "/:id" do |id|
-        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
-        <%= field_name %>.destroy
-        MultiJson.encode serialize(<%= field_name %>)
-      end
-
       patch "/:id" do |id|
         <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
         # warning: not safe
         <%= field_name %>.update(params)
+        MultiJson.encode serialize(<%= field_name %>)
+      end
+
+      delete "/:id" do |id|
+        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %>.destroy
         MultiJson.encode serialize(<%= field_name %>)
       end
 

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold.erb
@@ -1,0 +1,49 @@
+module Endpoints
+  class <%= endpoint_class_name %> < Base
+    namespace "<%= url_path %>" do
+      before do
+        content_type :json
+      end
+
+      get do
+        MultiJson.encode <%= model_class_name %>.all.map { |x| serialize(x) }
+      end
+
+      post do
+        # warning: not safe
+        <%= field_name %> = <%= model_class_name %>.new(params)
+        <%= field_name %>.save
+        status 201
+        MultiJson.encode serialize(<%= field_name %>)
+      end
+
+      get "/:id" do |id|
+        <%= field_name %> = <%= model_class_name %>.first(uuid: id) || halt(404)
+        MultiJson.encode serialize(<%= field_name %>)
+      end
+
+      delete "/:id" do |id|
+        <%= field_name %> = <%= model_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %>.destroy
+        MultiJson.encode serialize(<%= field_name %>)
+      end
+
+      patch "/:id" do |id|
+        <%= field_name %> = <%= model_class_name %>.first(uuid: id) || halt(404)
+        # warning: not safe
+        <%= field_name %>.update(params)
+        MultiJson.encode serialize(<%= field_name %>)
+      end
+
+      private
+
+      def serialize(data)
+        {
+          created_at: data.created_at.try(:iso8601),
+          id:         data.uuid,
+          updated_at: data.updated_at.try(:iso8601),
+        }
+      end
+    end
+  end
+end

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -26,8 +26,29 @@ describe Endpoints::<%= plural_class_name %> do
     assert_schema_conform
   end
 
+=begin
+  it "POST <%= url_path %>" do
+    post "<%= url_path %>", MultiJson.encode({})
+    assert_equal 201, last_response.status
+    assert_schema_conform
+  end
+=end
+
   it "GET <%= url_path %>/:id" do
     get "<%= url_path %>/#{@<%= field_name %>.uuid}"
+    assert_equal 200, last_response.status
+    assert_schema_conform
+  end
+
+  it "PATCH <%= url_path %>/:id" do
+    header "Content-Type", "application/json"
+    patch "<%= url_path %>/#{@<%= field_name %>.uuid}", MultiJson.encode({})
+    assert_equal 200, last_response.status
+    assert_schema_conform
+  end
+
+  it "GET <%= url_path %>/:id" do
+    delete "<%= url_path %>/#{@<%= field_name %>.uuid}"
     assert_equal 200, last_response.status
     assert_schema_conform
   end

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+describe Endpoints::<%= plural_class_name %> do
+  include Committee::Test::Methods
+  include Rack::Test::Methods
+
+  def app
+    Routes
+  end
+
+  def schema_path
+    App.root + "/docs/schema.json"
+  end
+
+  before do
+    @<%= field_name %> = <%= singular_class_name %>.create
+
+    # temporarily touch #updated_at until we can fix prmd
+    @<%= field_name %>.updated_at
+    @<%= field_name %>.save
+  end
+
+  it "GET <%= url_path %>" do
+    get "<%= url_path %>"
+    assert_equal 200, last_response.status
+    assert_schema_conform
+  end
+
+  it "GET <%= url_path %>/:id" do
+    get "<%= url_path %>/#{@<%= field_name %>.uuid}"
+    assert_equal 200, last_response.status
+    assert_schema_conform
+  end
+end

--- a/vendor/pliny/lib/pliny/templates/endpoint_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_test.erb
@@ -1,10 +1,10 @@
 require "test_helper"
 
-describe Endpoints::<%= endpoint_class_name %> do
+describe Endpoints::<%= plural_class_name %> do
   include Rack::Test::Methods
 
   def app
-    Endpoints::<%= endpoint_class_name %>
+    Endpoints::<%= plural_class_name %>
   end
 
   describe "GET <%= url_path %>" do

--- a/vendor/pliny/lib/pliny/templates/endpoint_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_test.erb
@@ -1,8 +1,10 @@
 require "test_helper"
 
-describe Endpoints::<%= class_name %> do
+describe Endpoints::<%= endpoint_class_name %> do
+  include Rack::Test::Methods
+
   def app
-    Endpoints::<%= class_name %>
+    Endpoints::<%= endpoint_class_name %>
   end
 
   describe "GET <%= url_path %>" do

--- a/vendor/pliny/lib/pliny/templates/mediator.erb
+++ b/vendor/pliny/lib/pliny/templates/mediator.erb
@@ -1,4 +1,4 @@
-class Mediators::<%= class_name %> < Mediators::Base
+class Mediators::<%= endpoint_class_name %> < Mediators::Base
   def initialize(args)
 
   end

--- a/vendor/pliny/lib/pliny/templates/mediator.erb
+++ b/vendor/pliny/lib/pliny/templates/mediator.erb
@@ -1,4 +1,4 @@
-class Mediators::<%= endpoint_class_name %> < Mediators::Base
+class Mediators::<%= plural_class_name %> < Mediators::Base
   def initialize(args)
 
   end

--- a/vendor/pliny/lib/pliny/templates/mediator_test.erb
+++ b/vendor/pliny/lib/pliny/templates/mediator_test.erb
@@ -1,5 +1,5 @@
 require "test_helper"
 
-describe Mediators::<%= endpoint_class_name %> do
+describe Mediators::<%= plural_class_name %> do
   
 end

--- a/vendor/pliny/lib/pliny/templates/mediator_test.erb
+++ b/vendor/pliny/lib/pliny/templates/mediator_test.erb
@@ -1,5 +1,5 @@
 require "test_helper"
 
-describe Mediators::<%= class_name %> do
+describe Mediators::<%= endpoint_class_name %> do
   
 end

--- a/vendor/pliny/lib/pliny/templates/model.erb
+++ b/vendor/pliny/lib/pliny/templates/model.erb
@@ -1,4 +1,4 @@
-class <%= model_class_name %> < Sequel::Model
+class <%= singular_class_name %> < Sequel::Model
 
   plugin :timestamps
 

--- a/vendor/pliny/lib/pliny/templates/model.erb
+++ b/vendor/pliny/lib/pliny/templates/model.erb
@@ -1,4 +1,4 @@
-class <%= class_name %> < Sequel::Model
+class <%= model_class_name %> < Sequel::Model
 
   plugin :timestamps
 

--- a/vendor/pliny/lib/pliny/templates/model_test.erb
+++ b/vendor/pliny/lib/pliny/templates/model_test.erb
@@ -1,5 +1,5 @@
 require "test_helper"
 
-describe <%= model_class_name %> do
+describe <%= singular_class_name %> do
   
 end

--- a/vendor/pliny/lib/pliny/templates/model_test.erb
+++ b/vendor/pliny/lib/pliny/templates/model_test.erb
@@ -1,5 +1,5 @@
 require "test_helper"
 
-describe <%= class_name %> do
+describe <%= model_class_name %> do
   
 end

--- a/vendor/pliny/test/commands/generator_test.rb
+++ b/vendor/pliny/test/commands/generator_test.rb
@@ -5,10 +5,17 @@ describe Pliny::Commands::Generator do
     @gen = Pliny::Commands::Generator.new({}, StringIO.new)
   end
 
-  describe "#class_name" do
-    it "builds a class name" do
+  describe "#endpoint_class_name" do
+    it "builds a class name for a model" do
       @gen.args = ["model", "resource_histories"]
-      assert_equal "ResourceHistory", @gen.class_name
+      assert_equal "ResourceHistories", @gen.endpoint_class_name
+    end
+  end
+
+  describe "#model_class_name" do
+    it "builds a class name for an endpoint" do
+      @gen.args = ["model", "resource_histories"]
+      assert_equal "ResourceHistory", @gen.model_class_name
     end
   end
 

--- a/vendor/pliny/test/commands/generator_test.rb
+++ b/vendor/pliny/test/commands/generator_test.rb
@@ -5,17 +5,17 @@ describe Pliny::Commands::Generator do
     @gen = Pliny::Commands::Generator.new({}, StringIO.new)
   end
 
-  describe "#endpoint_class_name" do
+  describe "#plural_class_name" do
     it "builds a class name for a model" do
       @gen.args = ["model", "resource_histories"]
-      assert_equal "ResourceHistories", @gen.endpoint_class_name
+      assert_equal "ResourceHistories", @gen.plural_class_name
     end
   end
 
-  describe "#model_class_name" do
+  describe "#singular_class_name" do
     it "builds a class name for an endpoint" do
       @gen.args = ["model", "resource_histories"]
-      assert_equal "ResourceHistory", @gen.model_class_name
+      assert_equal "ResourceHistory", @gen.singular_class_name
     end
   end
 

--- a/vendor/pliny/test/commands/generator_test.rb
+++ b/vendor/pliny/test/commands/generator_test.rb
@@ -44,6 +44,10 @@ describe Pliny::Commands::Generator do
       it "creates an endpoint test" do
         assert File.exists?("test/endpoints/artists_test.rb")
       end
+
+      it "creates an endpoint acceptance test" do
+        assert File.exists?("test/acceptance/artists_test.rb")
+      end
     end
 
     describe "generating mediators" do
@@ -77,6 +81,41 @@ describe Pliny::Commands::Generator do
 
       it "creates a test" do
         assert File.exists?("test/models/artist_test.rb")
+      end
+    end
+
+    describe "generating scaffolds" do
+      before do
+        @gen.args = ["scaffold", "artist"]
+        @gen.run!
+      end
+
+      it "creates a new endpoint module" do
+        assert File.exists?("lib/endpoints/artists.rb")
+      end
+
+      it "creates an endpoint test" do
+        assert File.exists?("test/endpoints/artists_test.rb")
+      end
+
+      it "creates an endpoint acceptance test" do
+        assert File.exists?("test/acceptance/artists_test.rb")
+      end
+
+      it "creates a migration" do
+        assert File.exists?("db/migrate/#{@t.to_i}_create_artists.rb")
+      end
+
+      it "creates the actual model" do
+        assert File.exists?("lib/models/artist.rb")
+      end
+
+      it "creates a test" do
+        assert File.exists?("test/models/artist_test.rb")
+      end
+
+      it "creates a schema" do
+        assert File.exists?("docs/schema/schemata/artists.json")
       end
     end
 

--- a/vendor/pliny/test/commands/generator_test.rb
+++ b/vendor/pliny/test/commands/generator_test.rb
@@ -91,4 +91,11 @@ describe Pliny::Commands::Generator do
       end
     end
   end
+
+  describe "#url_path" do
+    it "builds a URL path" do
+      @gen.args = ["endpoint", "resource_history"]
+      assert_equal "/resource-histories", @gen.url_path
+    end
+  end
 end


### PR DESCRIPTION
Generates a full scaffold for a new entity:

```
$ bundle exec pliny-generate scaffold artists
created endpoint file ./lib/endpoints/artists.rb
add the following to lib/routes.rb:
  use Endpoints::Artists
created test ./test/endpoints/artists_test.rb
created test ./test/acceptance/artists_test.rb
created model file ./lib/models/artists.rb
created migration ./db/migrate/1398048122_create_artists.rb
created test ./test/models/artists_test.rb
created schema file ./docs/schema/schemata/artist.json
rebuilt ./docs/schema.json
```

Scaffolded endpoints have some basic functionality built into them like the Rails equivalent:

``` ruby
  class Artists < Base
    namespace "/artists" do
      before do
        content_type :json
      end

      get do
        MultiJson.encode Artist.all.map { |x| serialize(x) }
      end

       ...
  end
```

Scaffolded acceptance tests check JSON Schema compliance using a Direwolf-like `assert_schema_conform` which I've recently pulled into Committee:

``` ruby
  it "GET /artists" do
    get "/artists"
    assert_equal 200, last_response.status
    assert_schema_conform
  end
```

A database migration needs to be run (hopefully we can pull this into the scaffolding function as well), but after it is, we get passing tests right away (the schemata is rebuilt by the generator):

```
$ rake
Run options: --seed 21072

# Running:

...

Finished in 0.047217s, 63.5364 runs/s, 63.5364 assertions/s.

3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

There are a few things left to do, but I'll probably leave them to other pulls:
- Scaffold mediators.
- Full serializers. I'm currently just using a method in the endpoint (which actually works pretty well).
