### PR TITLE
Add db_pool configuration option, for setting max_connections in Sequel

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -23,6 +23,7 @@ module Config
 
   # Override -- value is returned or the set default. Remember to typecast.
   override \
+    db_pool:          5,
     port:             5000,
     puma_max_threads: 16,
     puma_min_threads: 1,

--- a/config/initializers/db.rb
+++ b/config/initializers/db.rb
@@ -1,1 +1,1 @@
-DB = Sequel.connect(Config.database_url)
+DB = Sequel.connect(Config.database_url, max_connections: Config.db_pool)


### PR DESCRIPTION
Add db_pool optional config, with default 5 (Sequel default). Use by setting `DB_POOL` environment variable:

```
$ DB_POOL=2 foreman start
```

Or by adding to `.env`:

```
DATABASE_URL=postgres://...
RACK_ENV=development
TZ=UTC
DB_POOL=2
```
