### PR TITLE
Changed the way test_helper is being loaded

### DIFF
--- a/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative '../test_helper'
 
 describe Endpoints::<%= plural_class_name %> do
   include Committee::Test::Methods

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative '../test_helper'
 
 describe Endpoints::<%= plural_class_name %> do
   include Committee::Test::Methods

--- a/vendor/pliny/lib/pliny/templates/endpoint_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_test.erb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative '../test_helper'
 
 describe Endpoints::<%= plural_class_name %> do
   include Rack::Test::Methods

--- a/vendor/pliny/lib/pliny/templates/mediator_test.erb
+++ b/vendor/pliny/lib/pliny/templates/mediator_test.erb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative '../test_helper'
 
 describe Mediators::<%= plural_class_name %> do
   

--- a/vendor/pliny/lib/pliny/templates/model_test.erb
+++ b/vendor/pliny/lib/pliny/templates/model_test.erb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative '../test_helper'
 
 describe <%= singular_class_name %> do
   


### PR DESCRIPTION
When you run your tests like `ruby test_file_name.rb` it fails to load the `test_helper` file, this fixes it.
This also works with you run `rake` or `rake test` so it's compatible with both ways of running your tests.
