### PR TITLE
Move over to YAML-based JSON Schema fragments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     multi_json (1.9.2)
     oj (2.6.1)
     pg (0.17.1)
-    prmd (0.1.1)
+    prmd (0.2.0)
       erubis (~> 2.7)
     puma (2.7.1)
       rack (>= 1.1, < 2.0)

--- a/vendor/pliny/lib/pliny/commands/generator.rb
+++ b/vendor/pliny/lib/pliny/commands/generator.rb
@@ -159,9 +159,9 @@ module Pliny::Commands
     end
 
     def create_schema
-      schema = "./docs/schema/schemata/#{name.singularize}.json"
+      schema = "./docs/schema/schemata/#{name.singularize}.yaml"
       write_file(schema) do
-        Prmd.init(name.singularize)
+        Prmd.init(name.singularize, yaml: true)
       end
       display "created schema file #{schema}"
     end


### PR DESCRIPTION
Speaking generally, YAML is more human readable and writable, and its lack of commas and braces makes writing it less error prone.

&lt;/bikeshed&gt;

@pedro Any thoughts on this move? Kind of considering it for API/Psmgr as well ...
