### PR TITLE
Pull DATABASE_URL from ENV as well as .env and .env.test

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -96,14 +96,18 @@ namespace :db do
   private
 
   def database_urls
-    ([ENV["DATABASE_URL"]] + %w(.env .env.test).map { |env_file|
-      env_path = "./#{env_file}"
-      if File.exists?(env_path)
-        Pliny::Utils.parse_env(env_path)["DATABASE_URL"]
-      else
-        nil
-      end
-    }).compact
+    if ENV["DATABASE_URL"]
+      [ENV["DATABASE_URL"]]
+    else
+      %w(.env .env.test).map { |env_file|
+        env_path = "./#{env_file}"
+        if File.exists?(env_path)
+          Pliny::Utils.parse_env(env_path)["DATABASE_URL"]
+        else
+          nil
+        end
+      }.compact
+    end
   end
 
   def name_from_uri(uri)


### PR DESCRIPTION
Basically if `DATABASE_URL` is available in `ENV`, it's used, otherwise fall back on `.env` and `.env.test`.

The downside is there some's potential for confusion when users are in a development terminal and have `DATABASE_URL` set to something, and don't understand why normal migrations aren't happening (`unset DATABASE_URL` will do the trick).

Fixes #68.
