### PR TITLE
bin/setup improvements

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,7 @@ function main {
   set -e
 
   ensure_foreman_installed
-  cp .env.sample .env
+  add_new_env_vars
   bundle install
   rake db:setup db:schema:load db:migrate
 }
@@ -14,6 +14,21 @@ function ensure_foreman_installed {
     echo >&2 'Could not find `foreman` executable. Please install it.';
     false;
   }
+}
+
+function add_new_env_vars {
+  touch .env
+  export IFS=$'\n'
+  for var in `cat .env.sample`; do
+    key="${var%%=*}"     # get var key
+    var=`eval echo $var` # generate dynamic values
+
+    # If .env doesn't contain this env key, add it
+    if ! `grep -qLE "^$key=" .env`; then
+      echo "Adding $key to .env"
+      echo $var >> .env
+    fi
+  done
 }
 
 main

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 hash foreman 2>/dev/null || {
-  echo >&2 "Could not find `foreman` executable. Please install it.";
+  echo >&2 'Could not find `foreman` executable. Please install it.';
   exit 1;
 }
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 
-hash foreman 2>/dev/null || {
-  echo >&2 'Could not find `foreman` executable. Please install it.';
-  exit 1;
+function main {
+  set -e
+
+  ensure_foreman_installed
+  cp .env.sample .env
+  bundle install
+  rake db:setup db:schema:load db:migrate
 }
 
-cp .env.sample .env && bundle install && rake db:setup db:schema:load db:migrate
+function ensure_foreman_installed {
+  hash foreman 2>/dev/null || {
+    echo >&2 'Could not find `foreman` executable. Please install it.';
+    false;
+  }
+}
+
+main
+


### PR DESCRIPTION
- Fix bug in foreman check
- Re-structure `bin/setup` to be more readable as more steps are added
- Add non-destructive (incremental) `.env` creator, with a twist<sup>[1]</sup>, borrowed from one of my projects.

See long-form messages in commits for more details.

---

[1]: This one should probably be tested on Linux since some of the switches might be OS X / BSD specific.
