### PR TITLE
Strip Foreman check + recommend bundled Foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Clone this repo, then:
 
 ```bash
 $ bin/setup
-$ foreman start web
+$ bundle exec foreman start web
 ```
 
 There are some generators to help you get started:

--- a/bin/setup
+++ b/bin/setup
@@ -3,17 +3,9 @@
 function main {
   set -e
 
-  ensure_foreman_installed
   add_new_env_vars
   bundle install
   rake db:setup db:schema:load db:migrate
-}
-
-function ensure_foreman_installed {
-  hash foreman 2>/dev/null || {
-    echo >&2 'Could not find `foreman` executable. Please install it.';
-    false;
-  }
 }
 
 function add_new_env_vars {


### PR DESCRIPTION
I think our current implementation here is a little split brain: we
bundle Foreman, but then check for a system version, and error when you
don't have it.

The current implementation of `bin/setup` doesn't necessitate Foreman
anywhere, so firstly, pull that check out. Then recommend the use of the
bundled Foreman in the README.
