### PR TITLE
Use MiniTest assertions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,6 @@ group :test do
   gem "database_cleaner"
   gem "rack-test"
   gem "rr", require: false
-  gem "rspec-core"
-  gem "rspec-expectations"
+  gem "rspec-core", github: "rspec/rspec-core"
+  gem "rspec-support", github: "rspec/rspec-support"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: git://github.com/rspec/rspec-core.git
+  revision: 490bb145f83e97ee0632e42cffe2775412e468fe
+  specs:
+    rspec-core (3.0.0.beta2)
+      rspec-support (= 3.0.0.beta2)
+
+GIT
+  remote: git://github.com/rspec/rspec-support.git
+  revision: 5225b14dd23e1cbe60f3bd772f912f53c72d36b3
+  specs:
+    rspec-support (3.0.0.beta2)
+
 PATH
   remote: vendor/pliny
   specs:
@@ -25,7 +38,6 @@ GEM
       multi_json (> 0.0)
       rack (> 0.0)
     database_cleaner (1.2.0)
-    diff-lcs (1.2.5)
     dotenv (0.7.0)
     erubis (2.7.0)
     foreman (0.66.0)
@@ -51,9 +63,6 @@ GEM
       rack (>= 1.0)
     rake (10.2.2)
     rr (1.1.2)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
     sequel (4.8.0)
     sequel_pg (1.6.9)
       pg (>= 0.8.0)
@@ -93,8 +102,8 @@ DEPENDENCIES
   rack-test
   rake
   rr
-  rspec-core
-  rspec-expectations
+  rspec-core!
+  rspec-support!
   sequel
   sequel_pg
   sinatra

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.expect_with :minitest
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -10,31 +10,31 @@ describe Endpoints::<%= plural_class_name %> do
 
   it "GET <%= url_path %>" do
     get "<%= url_path %>"
-    last_response.status.should eq(200)
-    last_response.body.should eq("[]")
+    assert_equal 200, last_response.status
+    assert_equal "[]", last_response.body
   end
 
   it "POST <%= url_path %>/:id" do
     post "<%= url_path %>"
-    last_response.status.should eq(201)
-    last_response.body.should eq("{}")
+    assert_equal 201, last_response.status
+    assert_equal "{}", last_response.body
   end
 
   it "GET <%= url_path %>/:id" do
     get "<%= url_path %>/123"
-    last_response.status.should eq(200)
-    last_response.body.should eq("{}")
+    assert_equal 200, last_response.status
+    assert_equal "{}", last_response.body
   end
 
   it "PATCH <%= url_path %>/:id" do
     patch "<%= url_path %>/123"
-    last_response.status.should eq(200)
-    last_response.body.should eq("{}")
+    assert_equal 200, last_response.status
+    assert_equal "{}", last_response.body
   end
 
   it "DELETE <%= url_path %>/:id" do
     delete "<%= url_path %>/123"
-    last_response.status.should eq("{}")
-    last_response.body.should eq("{}")
+    assert_equal 200, last_response.status
+    assert_equal "{}", last_response.body
   end
 end

--- a/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -22,34 +22,34 @@ describe Endpoints::<%= plural_class_name %> do
 
   it "GET <%= url_path %>" do
     get "<%= url_path %>"
-    last_response.status.should eq(200)
+    assert_equal 200, last_response.status
     assert_schema_conform
   end
 
 =begin
   it "POST <%= url_path %>" do
     post "<%= url_path %>", MultiJson.encode({})
-    last_response.status.should eq(201)
+    assert_equal 201, last_response.status
     assert_schema_conform
   end
 =end
 
   it "GET <%= url_path %>/:id" do
     get "<%= url_path %>/#{@<%= field_name %>.uuid}"
-    last_response.status.should eq(200)
+    assert_equal 200, last_response.status
     assert_schema_conform
   end
 
   it "PATCH <%= url_path %>/:id" do
     header "Content-Type", "application/json"
     patch "<%= url_path %>/#{@<%= field_name %>.uuid}", MultiJson.encode({})
-    last_response.status.should eq(200)
+    assert_equal 200, last_response.status
     assert_schema_conform
   end
 
   it "GET <%= url_path %>/:id" do
     delete "<%= url_path %>/#{@<%= field_name %>.uuid}"
-    last_response.status.should eq(200)
+    assert_equal 200, last_response.status
     assert_schema_conform
   end
 end

--- a/vendor/pliny/lib/pliny/templates/endpoint_test.erb
+++ b/vendor/pliny/lib/pliny/templates/endpoint_test.erb
@@ -10,7 +10,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe "GET <%= url_path %>" do
     it "succeeds" do
       get "<%= url_path %>"
-      last_response.status.should eq(200)
+      assert_equal 200, last_response.status
     end
   end
 end


### PR DESCRIPTION
As brought up briefly in #65, here's a concept for replacing RSpec assertions with the ones provided by MiniTest. The main advantage here is that the unit test style assertions are a much more simple subset and will generally provide the vast majority of all matchers needed, which helps to reduce the diversity in testing styles across a codebase contributed to by many users.

Any thoughts?
