### PR TITLE
Fix Initializer.require_lib for serializers

### DIFF
--- a/lib/initializer.rb
+++ b/lib/initializer.rb
@@ -23,7 +23,7 @@ module Initializer
       lib/models/**/*
       lib/routes
       lib/serializers/base
-      lib/serializers/**/*.rb
+      lib/serializers/**/*
     )
   end
 


### PR DESCRIPTION
`.rb` will be added by `Initializer.require!`
