### PR TITLE
Bump to rspec 3, use rspec-mocks instead of rr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,5 @@ group :test do
   gem "committee"
   gem "database_cleaner"
   gem "rack-test"
-  gem "rr", require: false
-  gem "rspec-core"
-  gem "rspec-expectations"
+  gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,18 @@ GEM
     rack-test (0.6.2)
       rack (>= 1.0)
     rake (10.3.1)
-    rr (1.1.2)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.1)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.0)
     sequel (4.11.0)
     sequel-paranoid (0.4.3)
       sequel
@@ -93,9 +101,7 @@ DEPENDENCIES
   rack-ssl
   rack-test
   rake
-  rr
-  rspec-core
-  rspec-expectations
+  rspec
   sequel
   sequel-paranoid
   sequel_pg

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,6 @@ ENV["RACK_ENV"] = "test"
 require "bundler"
 Bundler.require(:default, :test)
 
-require "rr"
-
 root = File.expand_path("../../", __FILE__)
 ENV.update(Pliny::Utils.parse_env("#{root}/.env.test"))
 
@@ -23,8 +21,6 @@ DatabaseCleaner.strategy = :transaction
 Pliny::Utils.require_glob("#{Initializer.root}/spec/support/**/*.rb")
 
 RSpec.configure do |config|
-  config.mock_framework = :rr
-
   config.before :all do
     load('db/seeds.rb') if File.exist?('db/seeds.rb')
   end
@@ -37,7 +33,6 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,4 +41,9 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+
+  # the rack app to be tested with rack-test:
+  def app
+    @rack_app || fail("Missing @rack_app")
+  end
 end

--- a/spec/support/auto_define_rack_app.rb
+++ b/spec/support/auto_define_rack_app.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.before(:context) do |spec|
+    # weird ruby syntax, but test if the described_class inherits Sinatra::Base:
+    if !@rack_app && spec.described_class < Sinatra::Base
+      @rack_app = spec.described_class
+    end
+  end
+end


### PR DESCRIPTION
Following up to internal discussion, I personally went with rr for more flexibility in times I couldn't do things like `any_instance_of` with rspec, but a lot has changed since then.

Rspec 3 has been in beta for 6 months so it's probably good enough to upgrade. Overall I really like the changes/direction it's going, although slightly annoyed with the changes in expectations.

[Nice summary of the changes here](http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3)
