### PR TITLE
Middleware::RescueErrors shall only run in production

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,6 @@
 DATABASE_URL=postgres://localhost/pliny-development
 RACK_ENV=development
 TZ=UTC
+RESCUE_ERRORS=false
+FORCE_SSL=false
+TIMEOUT=false

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
 DATABASE_URL=postgres://localhost/pliny-test
 RACK_ENV=test
 TZ=UTC
+RESCUE_ERRORS=false
+FORCE_SSL=false

--- a/config/config.rb
+++ b/config/config.rb
@@ -21,6 +21,8 @@ module Config
   optional \
     :honeybadger_api_key,
     :placeholder
+    :versioning_default,
+    :versioning_app_name
 
   # Override -- value is returned or the set default. Remember to typecast.
   override \
@@ -33,4 +35,5 @@ module Config
     rescue_errors:    'true',
     timeout:          45,
     force_ssl:        'true',
+    versioning:       'false'
 end

--- a/config/config.rb
+++ b/config/config.rb
@@ -29,5 +29,8 @@ module Config
     puma_max_threads: 16,
     puma_min_threads: 1,
     puma_workers:     3,
-    rack_env:         "development"
+    rack_env:         'development',
+    rescue_errors:    'true',
+    timeout:          45,
+    force_ssl:        'true',
 end

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -5,6 +5,9 @@ Routes = Rack::Builder.new do
   use Pliny::Middleware::RequestID
   use Pliny::Middleware::RequestStore, store: Pliny::RequestStore
   use Pliny::Middleware::Timeout, timeout: Config.timeout.to_i if Config.timeout.to_i > 0
+  use Pliny::Middleware::Versioning,
+      default: Config.versioning_default,
+      app_name: Config.versioning_app_name if Config.versioning.downcase == 'true'
   use Rack::Deflater
   use Rack::MethodOverride
   use Rack::SSL if Config.force_ssl.downcase == 'true'

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,13 +1,13 @@
 Routes = Rack::Builder.new do
-  use Pliny::Middleware::RescueErrors unless Config.rack_env == "development"
+  use Pliny::Middleware::RescueErrors if Config.rescue_errors.downcase == 'true'
   use Honeybadger::Rack::ErrorNotifier if Config.honeybadger_api_key
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID
   use Pliny::Middleware::RequestStore, store: Pliny::RequestStore
-  use Pliny::Middleware::Timeout, timeout: 45
+  use Pliny::Middleware::Timeout, timeout: Config.timeout.to_i if Config.timeout.to_i > 0
   use Rack::Deflater
   use Rack::MethodOverride
-  use Rack::SSL if Config.rack_env == "production"
+  use Rack::SSL if Config.force_ssl.downcase == 'true'
 
   use Pliny::Router do
     # mount all endpoints here


### PR DESCRIPTION
Else its really hard to debug an error in one of the acceptance specs
