### PR TITLE
Update honeybadger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 ruby "2.1.2"
 
-gem "honeybadger"
+gem "honeybadger", '~> 1.14'
 gem "multi_json"
 gem "oj"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     foreman (0.67.0)
       dotenv (~> 0.7.0)
       thor (~> 0.17.0)
-    honeybadger (1.13.0)
+    honeybadger (1.15.0)
       json
     http_accept (0.1.5)
     i18n (0.6.9)
@@ -82,7 +82,7 @@ DEPENDENCIES
   committee
   database_cleaner
   foreman
-  honeybadger
+  honeybadger (~> 1.14)
   multi_json
   oj
   pg

--- a/config/config.rb
+++ b/config/config.rb
@@ -19,6 +19,7 @@ module Config
 
   # Optional -- value is returned or `nil` if it wasn't present.
   optional \
+    :honeybadger_api_key,
     :placeholder
 
   # Override -- value is returned or the set default. Remember to typecast.

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,3 +1,3 @@
 Honeybadger.configure do |config|
-  config.api_key = ENV["HONEYBADGER_API_KEY"]
+  config.api_key = Config.honeybadger_api_key
 end

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,6 +1,6 @@
 Routes = Rack::Builder.new do
   use Pliny::Middleware::RescueErrors unless Config.rack_env == "development"
-  use Honeybadger::Rack
+  use Honeybadger::Rack::ErrorNotifier if Config.honeybadger_api_key
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID
   use Pliny::Middleware::RequestStore, store: Pliny::RequestStore


### PR DESCRIPTION
`Honeybadger::Rack` is deprecated. Only load it, if `HONEYBADGER_API_KEY` is set 
