### PR TITLE
Use Pliny::Helpers::Params in Endpoint

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -3,6 +3,7 @@ module Endpoints
   class Base < Sinatra::Base
     register Pliny::Extensions::Instruments
     register Sinatra::Namespace
+    helpers Pliny::Helpers::Params
 
     configure :development do
       register Sinatra::Reloader


### PR DESCRIPTION
interagent/pliny#31

I think the helper has to be loaded in `Endpoints::Base`
