### PR TITLE
Pass in `raise` option instead of doing a condition include

### DIFF
--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,5 +1,5 @@
 Routes = Rack::Builder.new do
-  use Pliny::Middleware::RescueErrors if Config.rescue_errors.downcase == 'true'
+  use Pliny::Middleware::RescueErrors, raise: !Config.rescue_errors?
   use Honeybadger::Rack::ErrorNotifier if Config.honeybadger_api_key
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID


### PR DESCRIPTION
This will allow us to rescue Pliny-based exceptions while in a testing
environment, but allow unexpected exceptions to be raised as expected.
