### PR TITLE
Tweak Sinatra settings to allow errors to be rescued up stack

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -3,7 +3,11 @@ module Endpoints
   class Base < Sinatra::Base
     register Pliny::Extensions::Instruments
     register Sinatra::Namespace
+
     helpers Pliny::Helpers::Params
+
+    set :raise_errors, true
+    set :show_exceptions, false
 
     configure :development do
       register Sinatra::Reloader


### PR DESCRIPTION
Sinatra will by default swallow errors in its own stack. Tweak its settings to
allow those errors to be rescued up the stack.
