### PR TITLE
Set `dump_errors = false`

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://localhost/pliny-test
 RACK_ENV=test
 TZ=UTC
-RESCUE_ERRORS=false
+RAISE_ERRORS=true
 FORCE_SSL=false

--- a/config/config.rb
+++ b/config/config.rb
@@ -32,7 +32,7 @@ module Config
     puma_min_threads: 1,
     puma_workers:     3,
     rack_env:         'development',
-    rescue_errors:    'true',
+    raise_errors:     'false',
     timeout:          45,
     force_ssl:        'true',
     versioning:       'false'

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -6,6 +6,7 @@ module Endpoints
 
     helpers Pliny::Helpers::Params
 
+    set :dump_errors, false
     set :raise_errors, true
     set :show_exceptions, false
 

--- a/lib/routes.rb
+++ b/lib/routes.rb
@@ -1,5 +1,5 @@
 Routes = Rack::Builder.new do
-  use Pliny::Middleware::RescueErrors, raise: !Config.rescue_errors?
+  use Pliny::Middleware::RescueErrors, raise: Config.raise_errors?
   use Honeybadger::Rack::ErrorNotifier if Config.honeybadger_api_key
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID


### PR DESCRIPTION
Rather than have Sinatra dump errors to console, let's do it ourselves
so that we can silence expected classes of errors.

See also interagent/pliny#36.
