### PR TITLE
Add Pry support for Pliny

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem "multi_json"
 gem "oj"
 gem "pg"
 gem "pliny"
+gem "pry"
+gem "pry-doc"
 gem "puma"
 gem "rack-ssl"
 gem "rake"
@@ -16,6 +18,10 @@ gem "sinatra", require: "sinatra/base"
 gem "sinatra-contrib", require: ["sinatra/namespace", "sinatra/reloader"]
 gem "sinatra-router"
 gem "sucker_punch"
+
+group :development, :test do
+  gem "pry-byebug"
+end
 
 group :development do
   gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,18 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     backports (3.6.0)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
+    coderay (1.1.0)
+    columnize (0.8.9)
     committee (0.4.13)
       multi_json (> 0.0)
       rack (> 0.0)
     database_cleaner (1.2.0)
+    debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     dotenv (0.7.0)
     erubis (2.7.0)
@@ -23,11 +29,12 @@ GEM
     http_accept (0.1.5)
     i18n (0.6.9)
     json (1.8.1)
-    minitest (5.3.4)
+    method_source (0.8.2)
+    minitest (5.3.5)
     multi_json (1.10.1)
     oj (2.9.0)
     pg (0.17.1)
-    pliny (0.0.3)
+    pliny (0.1.0)
       activesupport (~> 4.1, >= 4.1.0)
       http_accept (~> 0.1, >= 0.1.5)
       multi_json (~> 1.9, >= 1.9.3)
@@ -38,6 +45,16 @@ GEM
       sinatra-router (~> 0.2, >= 0.2.3)
     prmd (0.3.2)
       erubis (~> 2.7)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
+    pry-doc (0.6.0)
+      pry (~> 0.9)
+      yard (~> 0.8)
     puma (2.8.2)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
@@ -81,6 +98,7 @@ GEM
       tilt (~> 1.3)
     sinatra-router (0.2.3)
       sinatra (~> 1.4)
+    slop (3.5.0)
     sucker_punch (1.0.5)
       celluloid (~> 0.15.2)
     thor (0.17.0)
@@ -89,6 +107,7 @@ GEM
     timers (1.1.0)
     tzinfo (1.2.1)
       thread_safe (~> 0.1)
+    yard (0.8.7.4)
 
 PLATFORMS
   ruby
@@ -101,6 +120,9 @@ DEPENDENCIES
   oj
   pg
   pliny
+  pry
+  pry-byebug
+  pry-doc
   puma
   rack-ssl
   rack-test

--- a/bin/console
+++ b/bin/console
@@ -1,9 +1,7 @@
 #!/usr/bin/env ruby
 
-require "irb"
-require "irb/completion"
 require "bundler"
 Bundler.require
 require "./lib/initializer"
 
-IRB.start
+binding.pry

--- a/bin/console
+++ b/bin/console
@@ -4,4 +4,28 @@ require "bundler"
 Bundler.require
 require "./lib/initializer"
 
-binding.pry
+def basic_prompt(target_self, nest_level, pry)
+  # override CONSOLE_BANNER to include something like a release identifier
+  nesting = nest_level.zero? ? "" : ":#{nest_level}"
+  "[#{pry.input_array.size}] #{console_prefix}(#{Pry.view_clip(target_self)})#{nesting}"
+end
+
+def console_prefix
+  if Config.console_banner
+    Config.console_banner
+  elsif Config.rack_env == "production"
+    "production"
+  end
+end
+
+Pry.prompt = [
+   proc { |target_self, nest_level, pry|
+     basic_prompt(target_self, nest_level, pry) + "> "
+   },
+
+   proc { |target_self, nest_level, pry|
+     basic_prompt(target_self, nest_level, pry) + "* "
+   }
+]
+
+Pry.start

--- a/config/config.rb
+++ b/config/config.rb
@@ -19,6 +19,7 @@ module Config
 
   # Optional -- value is returned or `nil` if it wasn't present.
   optional \
+    :console_banner,
     :placeholder,
     :versioning_default,
     :versioning_app_name


### PR DESCRIPTION
As discussed in #98, let's pull Pry in instead of standard IRB. It's
very useful as a console in development and production, and also hugely
useful for debugging in development and testing. It also seems to be
fairly well standardized in that many projects want to see its
inclusion.

Fixes #98.
