### PR TITLE
Render errors from within base endpoint

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -14,6 +14,10 @@ module Endpoints
       register Sinatra::Reloader
     end
 
+    error Pliny::Errors::Error do
+      Pliny::Errors::Error.render(env["sinatra.error"])
+    end
+
     not_found do
       content_type :json
       status 404


### PR DESCRIPTION
Depends on interagent/pliny#56.

Fixes interagent/pliny#54.
