### PR TITLE
Allow serializers to take arrays

### DIFF
--- a/lib/serializers/base.rb
+++ b/lib/serializers/base.rb
@@ -11,7 +11,14 @@ class Serializers
     end
 
     def serialize(object)
-      @@structures["#{self.class.name}::#{@type}"].call(object)
+      object.respond_to?(:map) ? object.map{|item| serializer.call(item)} : serializer.call(object)
     end
+
+    private
+
+    def serializer
+      @@structures["#{self.class.name}::#{@type}"]
+    end
+
   end
 end


### PR DESCRIPTION
At the moment serialization only allows individual objects to be serialized.
Arrays of objects need to be `map`'ed in the endpoint.  This commit changes that
so serialize can take one or many objects of a given type and sort it out so the
endpoint doesn't need to.
