### PR TITLE
Add encode helper

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -27,7 +27,7 @@ module Endpoints
     private
 
     def encode(hash)
-      MultiJson.encode(hash, pretty: params[:pretty] == 'true')
+      MultiJson.encode(hash, pretty: development? || params[:pretty] == 'true')
     end
   end
 end

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -27,7 +27,8 @@ module Endpoints
     private
 
     def encode(hash)
-      MultiJson.encode(hash, pretty: development? || params[:pretty] == 'true')
+      MultiJson.encode hash,
+                       pretty: development? || params[:pretty] == 'true'
     end
   end
 end

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -28,7 +28,7 @@ module Endpoints
 
     def encode(hash)
       MultiJson.encode hash,
-                       pretty: development? || params[:pretty] == 'true'
+                       pretty: self.class.development? || params[:pretty] == 'true'
     end
   end
 end

--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -23,5 +23,11 @@ module Endpoints
       status 404
       "{}"
     end
+
+    private
+
+    def encode(hash)
+      MultiJson.encode(hash, pretty: params[:pretty] == 'true')
+    end
   end
 end


### PR DESCRIPTION
My answer to https://github.com/interagent/http-api-design#keep-json-minified-in-all-responses

Shall this be in `Endpoints::Base` so that one can easily extend it or better as helper module in pliny?

Todo:
- [x] Update template in `pliny`
