### PR TITLE
Only enable Rollbar in production

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,4 +1,5 @@
 Rollbar.configure do |config|
+  config.enabled = ENV.has_key?('ROLLBAR_ACCESS_TOKEN')
   config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
   config.use_sucker_punch
 end


### PR DESCRIPTION
Without configuration, Rollbar is enabled in all environments. Is that the desired behavior?

I noticed the gem tried to report some errors on a spec run, but I didn't make my Rollbar credentials available in the test environment.
