### PR TITLE
Add application.rb

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 
-require "bundler"
-Bundler.require
-require "./lib/initializer"
+require_relative '../lib/application'
 
 def basic_prompt(target_self, nest_level, pry)
   # override CONSOLE_BANNER to include something like a release identifier

--- a/bin/run
+++ b/bin/run
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require "bundler"
-Bundler.require
-require "./lib/initializer"
+require_relative '../lib/application'
 
 eval ARGV.join(" ")

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,4 @@
-require "bundler"
-Bundler.require
-
-require "./lib/initializer"
+require_relative 'lib/application'
 
 $stdout.sync = true
 

--- a/lib/application.rb
+++ b/lib/application.rb
@@ -1,0 +1,4 @@
+require 'bundler'
+Bundler.require
+
+require_relative 'initializer'


### PR DESCRIPTION
Something like `application.rb` is necessary when using gems, like sidekiq, in the `Procfile`.

Add the following to your `Procfile`:

```
bundle exec sidekiq --require ./lib/application.rb
```
