### PR TITLE
set perms of .env to 0600 on init

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,7 +9,9 @@ function main {
 }
 
 function add_new_env_vars {
-  touch .env
+  # create .env and set perms if it does not exist
+  [ ! -f .env ] && { touch .env ; chmod 0600 .env ; }
+
   export IFS=$'\n'
   for var in `cat .env.sample`; do
     key="${var%%=*}"     # get var key


### PR DESCRIPTION
This patch sets the perms of `.env` to `0600` (read-write by owner only) if `bin/setup` is creating the file for the first time. Otherwise. `.env's perms will be determined by the user's umask which may not be appropriate for a file that could potentially contain creds.

As a data point, Ubuntu's default umask is `0002` which results in world-readable files.
