### PR TITLE
Improve reloader coverage

### DIFF
--- a/lib/endpoints/base.rb
+++ b/lib/endpoints/base.rb
@@ -13,6 +13,7 @@ module Endpoints
 
     configure :development do
       register Sinatra::Reloader
+      also_reload '../**/*.rb'
     end
 
     error Pliny::Errors::Error do


### PR DESCRIPTION
Currently development reloading only supports the 'default' Sinatra paths:
"files defining routes, filters, error handlers and inline templates".

This commit adds reloading to all of `lib`, thus including serializers,
mediators and the other common Pliny stuff, plus anything custom to the app.
