### PR TITLE
Rename console_banner to deployment

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,17 +3,9 @@
 require_relative '../lib/application'
 
 def basic_prompt(target_self, nest_level, pry)
-  # override CONSOLE_BANNER to include something like a release identifier
+  # override DEPLOYMENT to identify console sessions (eg: staging/production/etc)
   nesting = nest_level.zero? ? "" : ":#{nest_level}"
-  "[#{pry.input_array.size}] #{console_prefix}(#{Pry.view_clip(target_self)})#{nesting}"
-end
-
-def console_prefix
-  if Config.console_banner
-    Config.console_banner
-  elsif Config.rack_env == "production"
-    "production"
-  end
+  "[#{pry.input_array.size}] #{Config.deployment}(#{Pry.view_clip(target_self)})#{nesting}"
 end
 
 Pry.prompt = [

--- a/config/config.rb
+++ b/config/config.rb
@@ -13,13 +13,13 @@ module Config
   mandatory :database_url, string
 
   # Optional -- value is returned or `nil` if it wasn't present.
-  optional :console_banner,      string
   optional :placeholder,         string
   optional :versioning_default,  string
   optional :versioning_app_name, string
 
   # Override -- value is returned or the set default.
   override :db_pool,          5,    int
+  override :deployment,       'production', string
   override :port,             5000, int
   override :puma_max_threads, 16,   int
   override :puma_min_threads, 1,    int


### PR DESCRIPTION
more generic name indicates it's useful for other things, like
identifying metrics and exceptions (consider staging deployments
usually have RACK_ENV set to production)
