### PR TITLE
Remove explicit dependency to Foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ end
 
 group :development do
   gem 'dotenv'
-  gem "foreman"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
 end
 
 group :development do
-  gem 'dotenv'
+  gem "dotenv"
 end
 
 group :test do


### PR DESCRIPTION
Because people might use forego or others to launch processes.

And because Foreman depends on Thor on a different version than Pliny so `pliny-new foo` will give you an app set to run on Pliny 0.2.1 instead of 0.4.
